### PR TITLE
Revert "dos2unix is a pre-req until tidal-tools is fixed"

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,23 @@ The script `runner.ps1` should be customized for each environment.
 > _NB: You do need WinRM enabled across your environment for this._
 > _For a simple guide to do this via GPO, see [here](https://support.auvik.com/hc/en-us/articles/204424994-How-to-enable-WinRM-with-domain-controller-Group-Policy-for-WMI-monitoring)._
 
+### Usage
+
+1) Provide the needed Windows username to access to VMs.
+
+2) Ensure you are logged in to Tidal Migrations, via:
+```
+$ tidal login
+```
+
+3) Invoke the runner:
+```
+$ ./runner.ps1
+```
+
+You should be able to check your account and see the VMs and their corresponding attributes and metrics. You'll find that at a URL that is something like:
+
+https://your_domain.tidalmg.com/#/servers
 
 ### Data captured
 

--- a/windows/runner.ps1
+++ b/windows/runner.ps1
@@ -29,12 +29,6 @@ if(![System.IO.File]::Exists($securePwdFile)){
   Write-Output "Reading credential from $securePwdFile"
 } 
 
-$dos2unix = "$PWD\dos2unix.exe"
-if(![System.IO.File]::Exists($dos2unix)){
-  Write-Error "$dos2unix does not exist. Be sure to have the dos2unix.exe utility downloaded and available from this directory."
-  Write-Error "dos2unix can be downloaded here: https://sourceforge.net/projects/dos2unix/"
-  exit 1
-} 
 
 $secPwd = Get-Content "SecuredText.txt" | ConvertTo-SecureString
 $cred = New-Object System.Management.Automation.PSCredential -ArgumentList $username, $secPwd
@@ -100,10 +94,4 @@ Write-Output "Wrote to $outfile"
 
 # Cleanup:
 $jobs | Remove-Job
-
-# remove BOM from JSON file (the 90's called, they want their file encoding back!)
-.\dos2unix.exe -r $outfile 2>&1
-
-# Sync with Tidal:
-tidal sync servers $outfile 2>&1 
 

--- a/windows/runner.ps1
+++ b/windows/runner.ps1
@@ -95,3 +95,5 @@ Write-Output "Wrote to $outfile"
 # Cleanup:
 $jobs | Remove-Job
 
+# Sync with Tidal:
+tidal sync servers $outfile 2>&1

--- a/windows/runner.ps1
+++ b/windows/runner.ps1
@@ -1,10 +1,10 @@
-### 
+###
 # runner.ps1
 #
 # To use, simply:
-#  1. set your USERNAME below 
+#  1. set your USERNAME below
 #
-#  2. run the save_password.ps1 script to securely store your credential in 
+#  2. run the save_password.ps1 script to securely store your credential in
 #     SecuredText.txt
 #
 #  3. Save a list of server hostnames in servers.txt
@@ -27,13 +27,13 @@ if(![System.IO.File]::Exists($securePwdFile)){
   exit 1
 } else {
   Write-Output "Reading credential from $securePwdFile"
-} 
+}
 
 
 $secPwd = Get-Content "SecuredText.txt" | ConvertTo-SecureString
 $cred = New-Object System.Management.Automation.PSCredential -ArgumentList $username, $secPwd
 
-$env_user = Invoke-Command -ComputerName $env:COMPUTERNAME -Credential $cred -ScriptBlock { $env:USERNAME } 
+$env_user = Invoke-Command -ComputerName $env:COMPUTERNAME -Credential $cred -ScriptBlock { $env:USERNAME }
 Write-Output "About to execute inventory gathering as user: $env_user"
 
 
@@ -47,7 +47,7 @@ $server_list = Get-Content ".\servers.txt"
 # $server_list = @($env:COMPUTERNAME, $env:COMPUTERNAME, $env:COMPUTERNAME )
 
 $num_servers = $server_list.Count
-Write-Output "$num_servers Servers read from servers.txt" 
+Write-Output "$num_servers Servers read from servers.txt"
 
 # Collected server statistics go here:
 $server_stats = @()
@@ -59,10 +59,10 @@ $server_list | ForEach-Object {
 
 Do {
   $TotProgress = 0
-  ForEach ($job in $jobs) {   
+  ForEach ($job in $jobs) {
     Try {
       $Prog = ($job | Get-Job).ChildJobs[0].Progress.StatusDescription[-1]
-      If ($Prog -is [char]) {   
+      If ($Prog -is [char]) {
         $Prog = 0
       }
       $TotProgress += $Prog
@@ -75,10 +75,10 @@ Do {
   Write-Progress -Id 1 -Activity "Watching Background Jobs" -Status "Waiting for background jobs to complete: $TotProgress of $num_servers" -PercentComplete (($TotProgress / $num_servers) * 100)
   Start-Sleep -Seconds 3
 } Until (($jobs | Get-Job | Where-Object {(($_.State -eq “Running”) -or ($_.state -eq “NotStarted”))}).count -eq 0)
-  
+
 $jobs | Receive-Job | ForEach-Object {
   $server_stats += $_
-} 
+}
 
 $num_results = $server_stats.Count
 Write-Output "$num_results results received out of $num_servers servers."


### PR DESCRIPTION
This pull request removes dos2unix dependency that was introduced to mitigate a BOM issue, which has seen been handled internally in Tidal Tools.

This reverts commit 123366187c083b0de627d125fd4edfbe2a44153f.

When merged, it will close this open issue - https://github.com/tidalmigrations/machine_stats/issues/5