### PR TITLE
Fix dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ CPU name
 
 ### Requirements
 
-1. Install `virtualenv` and [activate virtual environment](https://virtualenv.pypa.io/en/latest/userguide/)
+1. Install `virtualenv` and [activate virtual environment](https://virtualenv.pypa.io/en/latest/user_guide.html)
 2. `pip install -r requirements.txt`
 3. [Add your SSH key to `ssh-agent`](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/#adding-your-ssh-key-to-the-ssh-agent) or have your SSH identity file available.
 


### PR DESCRIPTION
Fixes a dead link to the virtualenv docs in the readme. Looks like they changed the format of their url.
