### PR TITLE
Making hosts file(s) configurable via CLI args

### DIFF
--- a/unix/main.py
+++ b/unix/main.py
@@ -5,6 +5,7 @@ Script to prepare JSON output for tidal sync servers from the list of hosts
 from __future__ import division
 from __future__ import print_function
 
+import argparse
 import json
 import sys
 import shutil
@@ -136,6 +137,11 @@ class ResultCallback(CallbackBase):
 
 
 def main():
+    parser = argparse.ArgumentParser(prog='pipenv run stats')
+    parser.add_argument(
+        "hosts", metavar="FILE", type=str, help="hosts file", nargs="?", default="hosts"
+    )
+    args = parser.parse_args()
     # Since the API is constructed for CLI it expects certain options to always
     # be set in the context object
     context.CLIARGS = ImmutableDict(
@@ -160,7 +166,7 @@ def main():
 
     # Create inventory, use path to host config file as source or hosts in a
     # comma separated string
-    inventory = InventoryManager(loader=loader, sources="hosts")
+    inventory = InventoryManager(loader=loader, sources=args.hosts)
 
     # Variable manager takes care of merging all the different sources to give
     # you a unified view of variables available in each context

--- a/unix/main.py
+++ b/unix/main.py
@@ -137,11 +137,17 @@ class ResultCallback(CallbackBase):
 
 
 def main():
-    parser = argparse.ArgumentParser(prog='pipenv run stats')
+    parser = argparse.ArgumentParser(prog="pipenv run stats")
     parser.add_argument(
-        "hosts", metavar="FILE", type=str, help="hosts file", nargs="?", default="hosts"
+        "hosts",
+        metavar="FILE",
+        type=argparse.FileType("r"),
+        help="hosts file",
+        nargs="*",
+        default=[open("hosts")],
     )
     args = parser.parse_args()
+    sources = list(map(lambda f: f.name, args.hosts))
     # Since the API is constructed for CLI it expects certain options to always
     # be set in the context object
     context.CLIARGS = ImmutableDict(
@@ -166,7 +172,7 @@ def main():
 
     # Create inventory, use path to host config file as source or hosts in a
     # comma separated string
-    inventory = InventoryManager(loader=loader, sources=args.hosts)
+    inventory = InventoryManager(loader=loader, sources=sources)
 
     # Variable manager takes care of merging all the different sources to give
     # you a unified view of variables available in each context


### PR DESCRIPTION
This PR introduces the following changes:

- It makes it possible to provide a custom path to the inventory file (using `hosts` as the default value)
- It makes it possible to use multiple inventory files
- Adds short help message

```console
$ pipenv run stats # reads inventory from $PWD/hosts

$ pipenv run stats /path/to/my/hosts # reads inventory from /path/to/my/hosts

$ pipenv run stats hosts myhosts # reads inventory from hosts and myhosts

$ pipenv run stats --help
usage: pipenv run stats [-h] [FILE [FILE ...]]

positional arguments:
  FILE        hosts file

optional arguments:
  -h, --help  show this help message and exit
```