### PR TITLE
Add `cpu_sampling_timeout` field to the final output

### DIFF
--- a/unix/src/machine_stats/plugins/cpu_utilization.py
+++ b/unix/src/machine_stats/plugins/cpu_utilization.py
@@ -20,8 +20,14 @@ def add_arguments(parser):
 
 def ok_callback(parent, result):
     host = result._host.get_name()
+    cpu_sampling_timeout = result._result.get("timeout")
     cpu_util = result._result.get("ansible_cpu_utilization")
     if cpu_util is not None:
         parent.update_results(
-            host, {"cpu_average": cpu_util["average"], "cpu_peak": cpu_util["peak"]}
+            host,
+            {
+                "cpu_sampling_timeout": cpu_sampling_timeout,
+                "cpu_average": cpu_util["average"],
+                "cpu_peak": cpu_util["peak"],
+            },
         )


### PR DESCRIPTION
# Before

```console
$ machine_stats hosts
[
    {
        "cpu_average": 0.3499311152382123,
        "cpu_count": 1,
        "cpu_name": "Intel(R) Xeon(R) CPU @ 2.30GHz",
        "cpu_peak": 2.509212142481132,
        "fqdn": "instance-1.c.tidal-1529434400027.internal",
        "host_name": "instance-1",
        "ip_addresses": [
            "10.128.15.196",
            "fe80::4001:aff:fe80:fc4"
        ],
        "operating_system": "Debian",
        "operating_system_version": "10",
        "ram_allocated_gb": 0.5693359375,
        "ram_used_gb": 0.2255859375,
        "storage_allocated_gb": 9.778318405151367,
        "storage_used_gb": 1.8414325714111328
    }
]
```

# After

Look for `cpu_sampling_timeout` field.

```console
$ machine_stats hosts
[
    {
        "cpu_average": 0.3499311152382123,
        "cpu_count": 1,
        "cpu_name": "Intel(R) Xeon(R) CPU @ 2.30GHz",
        "cpu_peak": 2.509212142481132,
        "cpu_sampling_timeout": 30,
        "fqdn": "instance-1.c.tidal-1529434400027.internal",
        "host_name": "instance-1",
        "ip_addresses": [
            "10.128.15.196",
            "fe80::4001:aff:fe80:fc4"
        ],
        "operating_system": "Debian",
        "operating_system_version": "10",
        "ram_allocated_gb": 0.5693359375,
        "ram_used_gb": 0.2255859375,
        "storage_allocated_gb": 9.778318405151367,
        "storage_used_gb": 1.8414325714111328
    }
]

$ machine_stats --cpu-utilization-timeout 10
[
    {
        "cpu_average": 0.3499311152382123,
        "cpu_count": 1,
        "cpu_name": "Intel(R) Xeon(R) CPU @ 2.30GHz",
        "cpu_peak": 2.509212142481132,
        "cpu_sampling_timeout": 10,
        "fqdn": "instance-1.c.tidal-1529434400027.internal",
        "host_name": "instance-1",
        "ip_addresses": [
            "10.128.15.196",
            "fe80::4001:aff:fe80:fc4"
        ],
        "operating_system": "Debian",
        "operating_system_version": "10",
        "ram_allocated_gb": 0.5693359375,
        "ram_used_gb": 0.2255859375,
        "storage_allocated_gb": 9.778318405151367,
        "storage_used_gb": 1.8414325714111328
    }
]
```