### PR TITLE
Adding "servers" property to the final JSON output

### DIFF
--- a/unix/src/machine_stats/__init__.py
+++ b/unix/src/machine_stats/__init__.py
@@ -175,7 +175,11 @@ class ResultCallback(CallbackBase):
     def v2_playbook_on_stats(self, stats):
         if self._total_results is not None:
             print(
-                json.dumps(list(self._total_results.values()), indent=4, sort_keys=True)
+                json.dumps(
+                    {"servers": list(self._total_results.values())},
+                    indent=4,
+                    sort_keys=True,
+                )
             )
 
         self._display.banner("MACHINE STATS RECAP")


### PR DESCRIPTION
This PR fixes the regression with JSON output incompatible with Tidal Tools. Thanks @fortran01!

```
{
    "servers": [
        {                                                                                 
            "cpu_average": 0.13370340845604106,                                           
            "cpu_count": 1,                                                               
            "cpu_name": "Intel(R) Xeon(R) CPU @ 2.30GHz",                                 
            "cpu_peak": 0.990099009900991,                                                
            "cpu_sampling_timeout": 30,                                                   
            "fqdn": "instance-1.c.tidal-1529434400027.internal",                          
            "host_name": "instance-1",                                                    
            "ip_addresses": [                                                             
                "10.128.15.196",
                "fe80::4001:aff:fe80:fc4"
            ],
            "operating_system": "Debian",
            "operating_system_version": "10",
            "ram_allocated_gb": 0.5693359375,
            "ram_used_gb": 0.50390625,
            "storage_allocated_gb": 9.778318405151367,
            "storage_used_gb": 1.8452091217041016
        }
    ]
}

```