### PR TITLE
Adding CPU utilization data to the `custom_fields` property

### DIFF
--- a/unix/src/machine_stats/plugins/cpu_utilization.py
+++ b/unix/src/machine_stats/plugins/cpu_utilization.py
@@ -26,8 +26,10 @@ def ok_callback(parent, result):
         parent.update_results(
             host,
             {
-                "cpu_sampling_timeout": cpu_sampling_timeout,
-                "cpu_average": cpu_util["average"],
-                "cpu_peak": cpu_util["peak"],
+                "custom_fields": {
+                    "cpu_sampling_timeout": cpu_sampling_timeout,
+                    "cpu_average": cpu_util["average"],
+                    "cpu_peak": cpu_util["peak"],
+                }
             },
         )


### PR DESCRIPTION
This PR adds the CPU utilization data to the `custom_fields` property, so it would play nice with Tidal Tools and Tidal Migrations API.

## Before

```
{
    "servers": [
        {
            "cpu_count": 1,
            "cpu_name": "Intel(R) Xeon(R) CPU @ 2.30GHz",
            "cpu_average": 0.20447975806933325,
            "cpu_peak": 3.164095712377024,
            "cpu_sampling_timeout": 30
            "fqdn": "instance-1.c.tidal-1529434400027.internal",
            "host_name": "instance-1",
            "ip_addresses": [
                "10.128.15.201",
                "fe80::4001:aff:fe80:fc9"
            ],
            "operating_system": "Debian",
            "operating_system_version": "10",
            "ram_allocated_gb": 0.5673828125,
            "ram_used_gb": 0.2255859375,
            "storage_allocated_gb": 9.778318405151367,
            "storage_used_gb": 1.8576221466064453
        }
    ]
}
```

## After

```
{
    "servers": [
        {
            "cpu_count": 1,
            "cpu_name": "Intel(R) Xeon(R) CPU @ 2.30GHz",
            "custom_fields": {
                "cpu_average": 0.20447975806933325,
                "cpu_peak": 3.164095712377024,
                "cpu_sampling_timeout": 30
            },
            "fqdn": "instance-1.c.tidal-1529434400027.internal",
            "host_name": "instance-1",
            "ip_addresses": [
                "10.128.15.201",
                "fe80::4001:aff:fe80:fc9"
            ],
            "operating_system": "Debian",
            "operating_system_version": "10",
            "ram_allocated_gb": 0.5673828125,
            "ram_used_gb": 0.2255859375,
            "storage_allocated_gb": 9.778318405151367,
            "storage_used_gb": 1.8576221466064453
        }
    ]
}
```