### PR TITLE
Fixes for windows machine stats

### DIFF
--- a/windows/runner.ps1
+++ b/windows/runner.ps1
@@ -88,8 +88,14 @@ Write-Output "$num_results results received out of $num_servers servers."
 $results = @{ "servers" = $server_stats; }
 $date = Get-Date -format yyyy_MM_dd
 $outfile = "./$date-server_stats.json"
-$results | ConvertTo-Json -depth 99 | Out-File $outfile -Encoding utf8 -Force
+$json = $results | ConvertTo-Json -depth 99
 
+# Sets current directory to this scripts location
+Write-Output "[System.Environment]::CurrentDirectory"
+[System.Environment]::CurrentDirectory = (Get-Location).Path
+
+# This write ensures that the file is written without a BOM, and a UTF-8 encoding.
+[IO.File]::WriteAllLines($outfile, $json)
 Write-Output "Wrote to $outfile"
 
 # Cleanup:

--- a/windows/runner.ps1
+++ b/windows/runner.ps1
@@ -102,4 +102,4 @@ Write-Output "Wrote to $outfile"
 $jobs | Remove-Job
 
 # Sync with Tidal:
-tidal sync servers $outfile 2>&1
+Get-Content -Path $outfile -ReadCount 500 | tidal sync servers


### PR DESCRIPTION
Includes two fixes, that currently prevent execution in a windows environment:

- Generate json file without BOM
- Sync files to tidal with pipe, avoid interactive prompts
