### PR TITLE
Adding braces to retrieve the value

### DIFF
--- a/windows/runner.ps1
+++ b/windows/runner.ps1
@@ -33,7 +33,7 @@ if(![System.IO.File]::Exists($securePwdFile)){
 $secPwd = Get-Content "SecuredText.txt" | ConvertTo-SecureString
 $cred = New-Object System.Management.Automation.PSCredential -ArgumentList $username, $secPwd
 
-$env_user = Invoke-Command -ComputerName [Environment]::MachineName -Credential $cred -ScriptBlock { $env:USERNAME }
+$env_user = Invoke-Command -ComputerName ([Environment]::MachineName) -Credential $cred -ScriptBlock { $env:USERNAME }
 Write-Output "About to execute inventory gathering as user: $env_user"
 
 


### PR DESCRIPTION
Without braces PowerShell uses the parameter _as is_, but with braces it retrieves the actual value, for example:
![image](https://user-images.githubusercontent.com/290451/130686202-2a13995d-4d04-4786-81be-9d8f50b575f2.png)
