### PR TITLE
Make Machine Stats for Windows output JSON

### DIFF
--- a/windows/README.md
+++ b/windows/README.md
@@ -31,9 +31,9 @@ You can easily export these with the 'Export' button from your Tidal Migrations 
 ./windows/save_password.ps1
 ```
 
-5) Invoke the runner:
+5) Invoke the runner and sync with Tidal Migrations:
 ```
-./windows/runner.ps1
+./windows/runner.ps1 | tidal sync servers
 ```
 
 You should be able to check your account and see the VMs and their corresponding attributes and metrics. You'll find that at a URL that is something like:

--- a/windows/runner.ps1
+++ b/windows/runner.ps1
@@ -84,21 +84,9 @@ $num_results = $server_stats.Count
 Write-Host "$num_results results received out of $num_servers servers."
 
 
-# Write results to file:
-$results = @{ "servers" = $server_stats; }
-$date = Get-Date -format yyyy_MM_dd
-$outfile = "./$date-server_stats.json"
+# Output results
 $json = $results | ConvertTo-Json -depth 99
-
-# Sets current directory to this scripts location
-[System.Environment]::CurrentDirectory = (Get-Location).Path
-
-# This write ensures that the file is written without a BOM, and a UTF-8 encoding.
-[IO.File]::WriteAllLines($outfile, $json)
-Write-Host "Wrote to $outfile"
+Write-Output $json
 
 # Cleanup:
 $jobs | Remove-Job
-
-# Sync with Tidal:
-Get-Content -Path $outfile -ReadCount 500 | tidal sync servers

--- a/windows/runner.ps1
+++ b/windows/runner.ps1
@@ -26,7 +26,7 @@ if(![System.IO.File]::Exists($securePwdFile)){
   Write-Error "$securePwdFile does not exist. Be sure to run save_password.ps1 before trying again."
   exit 1
 } else {
-  Write-Output "Reading credential from $securePwdFile"
+  Write-Host "Reading credential from $securePwdFile"
 }
 
 
@@ -34,7 +34,7 @@ $secPwd = Get-Content "SecuredText.txt" | ConvertTo-SecureString
 $cred = New-Object System.Management.Automation.PSCredential -ArgumentList $username, $secPwd
 
 $env_user = Invoke-Command -ComputerName [Environment]::MachineName -Credential $cred -ScriptBlock { $env:USERNAME }
-Write-Output "About to execute inventory gathering as user: $env_user"
+Write-Host "About to execute inventory gathering as user: $env_user"
 
 
 # Load the ScriptBlock $ServerStats:
@@ -47,7 +47,7 @@ $server_list = Get-Content ".\servers.txt"
 # $server_list = @($env:COMPUTERNAME, $env:COMPUTERNAME, $env:COMPUTERNAME )
 
 $num_servers = $server_list.Count
-Write-Output "$num_servers Servers read from servers.txt"
+Write-Host "$num_servers Servers read from servers.txt"
 
 # Collected server statistics go here:
 $server_stats = @()
@@ -81,7 +81,7 @@ $jobs | Receive-Job | ForEach-Object {
 }
 
 $num_results = $server_stats.Count
-Write-Output "$num_results results received out of $num_servers servers."
+Write-Host "$num_results results received out of $num_servers servers."
 
 
 # Write results to file:
@@ -95,7 +95,7 @@ $json = $results | ConvertTo-Json -depth 99
 
 # This write ensures that the file is written without a BOM, and a UTF-8 encoding.
 [IO.File]::WriteAllLines($outfile, $json)
-Write-Output "Wrote to $outfile"
+Write-Host "Wrote to $outfile"
 
 # Cleanup:
 $jobs | Remove-Job


### PR DESCRIPTION
This PR introduces the following changes:

1. Use `Write-Host` for information messages instead of `Write-Output` which can be piped
2. Remove saving data to a file. If it's needed it can be done by redirection: `.\runner.ps1 > servers.json`
3. Update `README` with the information of how to pipe the output to `tidal sync servers`