### PR TITLE
Machine Stats for Windows Fixes

### DIFF
--- a/windows/runner.ps1
+++ b/windows/runner.ps1
@@ -33,7 +33,7 @@ if(![System.IO.File]::Exists($securePwdFile)){
 $secPwd = Get-Content "SecuredText.txt" | ConvertTo-SecureString
 $cred = New-Object System.Management.Automation.PSCredential -ArgumentList $username, $secPwd
 
-$env_user = Invoke-Command -ComputerName [Environment]::MachineName -Credential $cred -ScriptBlock { $env:USERNAME }
+$env_user = Invoke-Command -ComputerName ([Environment]::MachineName) -Credential $cred -ScriptBlock { $env:USERNAME }
 Write-Host "About to execute inventory gathering as user: $env_user"
 
 


### PR DESCRIPTION
This PR adds the following changes:

1. Actually creates `$results` object (the line was accidentally deleted in #82)
2. Adding braces to retrieve the value (re-implements #81)