### PR TITLE
Connect to qemu:///system

### DIFF
--- a/libvirt/CONTRIBUTING.md
+++ b/libvirt/CONTRIBUTING.md
@@ -14,6 +14,7 @@ Under the hood Virt Stats relies on awesome [libvirt](https://libvirt.org/).
     ```
     $ qemu-img create -f qcow2 ./debian9.qcow2 8G
     $ virt-install \
+        --connect qemu:///system \
         --name debian9 \
         --ram 1024 \
         --disk path=./debian9.qcow2,size=8 \


### PR DESCRIPTION
By default `virt-install` connects to `qemu://session`. Connecting to `qemu:///system` will make it easier to connect for the remote machines.