### PR TITLE
Setting default configuration parameters

### DIFF
--- a/unix/src/machine_stats/__init__.py
+++ b/unix/src/machine_stats/__init__.py
@@ -10,6 +10,14 @@ from functools import partial
 
 from ansible.utils.path import unfrackpath
 
+# Setting default configuration parameters
+default_config = {
+    "ANSIBLE_HOST_KEY_CHECKING": False,
+    "ANSIBLE_GATHER_TIMEOUT": 180,
+}
+for k, v in default_config.items():
+    os.environ[k] = v
+
 # Loading config file must be prior to importing most of the ansible.* packages
 def find_config_file():
     """Find configuration file"""


### PR DESCRIPTION
This PR sets the following configuration parameters as defaults:

```
host_key_checking = False
gather_timeout = 180
```

So, there's no need to explicitly state the above values in [Machine Stats configuration file](https://github.com/tidalmigrations/machine_stats/tree/master/unix#configuration).