### PR TITLE
Cast time into int to ensure proper formatting in json

### DIFF
--- a/windows/server_stats.ps1
+++ b/windows/server_stats.ps1
@@ -4,7 +4,7 @@ $ServerStats = {
     # Helper Functions for aggregating process information
     $memory_used_mb = {[math]::Round(($_.WorkingSet64 / 1MB), 2)};
     $max_memory_used_mb = {[math]::Round(($_.PeakWorkingSet64 / 1MB), 2)};
-    $process_alive_time = {[math]::Round((New-TimeSpan -Start $_.StartTime -End (Get-Date)).TotalSeconds)}
+    $process_alive_time = {[[int] (New-TimeSpan -Start $_.StartTime -End (Get-Date)).TotalSeconds}
     $is_admin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")
 
     $CPUInfo = Get-WmiObject Win32_Processor 


### PR DESCRIPTION
Previously alive time would print as float, `1.0`, this caused parsing
errors to show up in tidal tools. This also seems to go against
Powershell docs where [Math]::Round should have turned that into
`1`. 

Instead we have to switch to casting the float into an int which
guarantees that the value won't have a trailing zero.