### PR TITLE
Fix default configuration values types

### DIFF
--- a/unix/src/machine_stats/__init__.py
+++ b/unix/src/machine_stats/__init__.py
@@ -12,8 +12,8 @@ from ansible.utils.path import unfrackpath
 
 # Setting default configuration parameters
 default_config = {
-    "ANSIBLE_HOST_KEY_CHECKING": False,
-    "ANSIBLE_GATHER_TIMEOUT": 180,
+    "ANSIBLE_HOST_KEY_CHECKING": "False",
+    "ANSIBLE_GATHER_TIMEOUT": "180",
 }
 for k, v in default_config.items():
     os.environ[k] = v


### PR DESCRIPTION
This PR introduces the hot fix for the default configuration values.

`os.environ` is a mapping object where keys and values are **strings** that represent the process environment, that's why the values were changed into strings.