### PR TITLE
Virt-Stats: adding CPU count and RAM allocated and used (GB)

### DIFF
--- a/libvirt/README.md
+++ b/libvirt/README.md
@@ -21,6 +21,8 @@ As of now Virt-Stats captures the following metrics:
 
 * Hostname
 * IP Addresses
+* CPU count
+* RAM allocated (GB)
 
 ## Usage
 

--- a/libvirt/README.md
+++ b/libvirt/README.md
@@ -23,6 +23,7 @@ As of now Virt-Stats captures the following metrics:
 * IP Addresses
 * CPU count
 * RAM allocated (GB)
+* RAM used (GB)
 
 ## Usage
 

--- a/libvirt/src/virt_stats/__init__.py
+++ b/libvirt/src/virt_stats/__init__.py
@@ -63,6 +63,11 @@ def ip_addresses(domain: libvirt.virDomain):
                     ips.append(ipaddr["addr"])
     return ips
 
+def memory_stats_gb(memory_stats: dict, tag: str):
+    v = memory_stats.get(tag)
+    if not v:
+        return None
+    return v / 1024 ** 2 # convert kb to gb
 
 def main():
     parser = argparse.ArgumentParser(prog="virt-stats")
@@ -78,10 +83,14 @@ def main():
 
     results = []
     for domain in conn.listAllDomains(libvirt.VIR_CONNECT_LIST_DOMAINS_ACTIVE):
+        memory_stats = domain.memoryStats()
         results.append(
             {
+                "cpu_count": domain.vcpusFlags(),
                 "host_name": hostname(domain),
                 "ip_addresses": ip_addresses(domain),
+                "ram_allocated_gb": memory_stats_gb(memory_stats, "available"),
+                "ram_used_gb": memory_stats_gb(memory_stats, "actual"),
             }
         )
 

--- a/libvirt/src/virt_stats/__init__.py
+++ b/libvirt/src/virt_stats/__init__.py
@@ -89,8 +89,7 @@ def main():
                 "cpu_count": domain.vcpusFlags(),
                 "host_name": hostname(domain),
                 "ip_addresses": ip_addresses(domain),
-                "ram_allocated_gb": memory_stats_gb(memory_stats, "available"),
-                "ram_used_gb": memory_stats_gb(memory_stats, "actual"),
+                "ram_allocated_gb": round(memory_stats_gb(memory_stats, "available"), 2)
             }
         )
 


### PR DESCRIPTION
This PR introduces the following changes:

1. Adds `cpu_count` to the final JSON output
2. Adds `ram_allocated_gb` to the final JSON output
3. Adds `ram_used_gb` to the final JSON output
4. Updates the `README`

Sample output

```json
[
    {
        "cpu_count": 2,
        "host_name": "debian",
        "ip_addresses": [
            "192.168.122.124"
        ],
        "ram_allocated_gb": 3.85,
        "ram_used_gb": 0.08
    }
]
```

[![asciicast](https://asciinema.org/a/1lkMfZ17iH65T4DH40Yu3WqCH.svg)](https://asciinema.org/a/1lkMfZ17iH65T4DH40Yu3WqCH)