### PR TITLE
Adding NoWinRM and ProcessStats parameters

### DIFF
--- a/windows/runner.ps1
+++ b/windows/runner.ps1
@@ -48,11 +48,11 @@ param (
 
 $securePwdFile = Join-Path -Path $PWD -ChildPath "SecuredText.txt"
 
-if(![System.IO.File]::Exists($securePwdFile)){
-  Write-Error "$securePwdFile does not exist. Be sure to run save_password.ps1 before trying again."
-  exit 1
+if (![System.IO.File]::Exists($securePwdFile)) {
+    Write-Error "$securePwdFile does not exist. Be sure to run save_password.ps1 before trying again."
+    exit 1
 } else {
-  Write-Host "Reading credential from $securePwdFile"
+    Write-Host "Reading credential from $securePwdFile"
 }
 
 
@@ -78,30 +78,29 @@ $server_stats = @()
 $jobs = @()
 
 $server_list | ForEach-Object {
-  $jobs += Invoke-Command -ComputerName $_ -Credential $cred -ScriptBlock $ServerStats -AsJob
+    $jobs += Invoke-Command -ComputerName $_ -Credential $cred -ScriptBlock $ServerStats -AsJob
 }
 
 Do {
-  $TotProgress = 0
-  ForEach ($job in $jobs) {
-    Try {
-      $Prog = ($job | Get-Job).ChildJobs[0].Progress.StatusDescription[-1]
-      If ($Prog -is [char]) {
-        $Prog = 0
-      }
-      $TotProgress += $Prog
+    $TotProgress = 0
+    ForEach ($job in $jobs) {
+        Try {
+            $Prog = ($job | Get-Job).ChildJobs[0].Progress.StatusDescription[-1]
+            If ($Prog -is [char]) {
+                $Prog = 0
+            }
+            $TotProgress += $Prog
+        } Catch {
+            Start-Sleep -Milliseconds 500
+            Break
+        }
     }
-    Catch {
-      Start-Sleep -Milliseconds 500
-      Break
-    }
-  }
-  Write-Progress -Id 1 -Activity "Watching Background Jobs" -Status "Waiting for background jobs to complete: $TotProgress of $num_servers" -PercentComplete (($TotProgress / $num_servers) * 100)
-  Start-Sleep -Seconds 3
-} Until (($jobs | Get-Job | Where-Object {(($_.State -eq "Running") -or ($_.state -eq "NotStarted"))}).count -eq 0)
+    Write-Progress -Id 1 -Activity "Watching Background Jobs" -Status "Waiting for background jobs to complete: $TotProgress of $num_servers" -PercentComplete (($TotProgress / $num_servers) * 100)
+    Start-Sleep -Seconds 3
+} Until (($jobs | Get-Job | Where-Object { (($_.State -eq "Running") -or ($_.state -eq "NotStarted")) }).count -eq 0)
 
 $jobs | Receive-Job | ForEach-Object {
-  $server_stats += $_
+    $server_stats += $_
 }
 
 $num_results = $server_stats.Count
@@ -110,7 +109,7 @@ Write-Host "$num_results results received out of $num_servers servers."
 
 # Output results
 $results = @{ servers = $server_stats }
-$json = $results | ConvertTo-Json -depth 99
+$json = $results | ConvertTo-Json -Depth 99
 Write-Output $json
 
 # Cleanup:

--- a/windows/save_password.ps1
+++ b/windows/save_password.ps1
@@ -1,6 +1,6 @@
 
 # Do this once, to save your password to a secure string on disk:
-$securePassword =  Read-host "What's your password?" -AsSecureString | ConvertFrom-SecureString
+$securePassword = Read-Host "What's your password?" -AsSecureString | ConvertFrom-SecureString
 Set-Content "SecuredText.txt" $securePassword
 
 Write-Output "Wrote securePassword to SecuredText.txt"

--- a/windows/server_stats.ps1
+++ b/windows/server_stats.ps1
@@ -20,6 +20,7 @@ $ServerStats = {
         Namespace     = "ROOT\cimv2"
         Impersonation = 3 # Impersonate. Allows objects to use the credentials of the caller.
     }
+    # If $remote is $true, it means that -NoWinRM parameter was set.
     $remote = $ComputerName -notin ".", "localhost", ([System.Environment]::MachineName)
     if ($remote) {
         $getWmiObjectParams | Add-Member -NotePropertyName Credential -NotePropertyValue $Credential

--- a/windows/server_stats.ps1
+++ b/windows/server_stats.ps1
@@ -2,9 +2,9 @@
 # in the ServerStats code block
 $ServerStats = {
     # Helper Functions for aggregating process information
-    $memory_used_mb = {[math]::Round(($_.WorkingSet64 / 1MB), 2)};
-    $max_memory_used_mb = {[math]::Round(($_.PeakWorkingSet64 / 1MB), 2)};
-    $process_alive_time = {[[int] (New-TimeSpan -Start $_.StartTime -End (Get-Date)).TotalSeconds}
+    $memory_used_mb = { [math]::Round(($_.WorkingSet64 / 1MB), 2) };
+    $max_memory_used_mb = { [math]::Round(($_.PeakWorkingSet64 / 1MB), 2) };
+    $process_alive_time = { [[int] (New-TimeSpan -Start $_.StartTime -End (Get-Date)).TotalSeconds }
     $is_admin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")
 
     $CPUInfo = Get-WmiObject Win32_Processor 
@@ -20,12 +20,12 @@ $ServerStats = {
     # Get Memory Information. 
     # The data will be shown in a table as MB, rounded to the nearest second decimal. 
     $OSTotalVirtualMemory = [math]::round($OSInfo.TotalVirtualMemorySize / 1MB, 2) 
-    $OSTotalVisibleMemory = [math]::round(($OSInfo.TotalVisibleMemorySize  / 1MB), 2) 
-    $OSFreeVisibleMemory = [math]::round(($OSInfo.FreePhysicalMemory  / 1MB), 2) 
+    $OSTotalVisibleMemory = [math]::round(($OSInfo.TotalVisibleMemorySize / 1MB), 2) 
+    $OSFreeVisibleMemory = [math]::round(($OSInfo.FreePhysicalMemory / 1MB), 2) 
     $OSUsedMemory = "{0:N2}" -f $OSTotalVisibleMemory - $OSFreeVisibleMemory
     $PhysicalMemory = Get-WmiObject CIM_PhysicalMemory |
-        Measure-Object -Property capacity -Sum |
-            ForEach-Object { [math]::round(($_.sum / 1GB), 2) } 
+    Measure-Object -Property capacity -Sum |
+    ForEach-Object { [math]::round(($_.sum / 1GB), 2) } 
     $Disk = Get-WMIObject Win32_LogicalDisk
     $Total_FreeSpaceGB = 0
     $Total_DriveSpaceGB = 0
@@ -38,14 +38,14 @@ $ServerStats = {
     $Total_UsedDriveSpaceGB = $Total_DriveSpaceGB - $Total_FreeSpaceGB
 
     $counter_params = @{
-        Counter = "\Processor(_Total)\% Processor Time"
+        Counter        = "\Processor(_Total)\% Processor Time"
         SampleInterval = 1
-        MaxSamples = 30
+        MaxSamples     = 30
     }
     $CPUUtilization = (Get-Counter @counter_params |
         Select-Object -ExpandProperty countersamples |
-            Select-Object -ExpandProperty CookedValue |
-                Measure-Object -Average -Maximum)
+        Select-Object -ExpandProperty CookedValue |
+        Measure-Object -Average -Maximum)
 
     # if ($is_admin){
     # # Get Information on current running processes
@@ -70,31 +70,31 @@ $ServerStats = {
 
     # Create an object to return, convert this to JSON or CSV as you need:
     $server_info = New-Object -TypeName psobject -Property @{
-        host_name = $cpu.SystemName
-        ram_allocated_gb = $PhysicalMemory 
-        ram_used_gb = $OSUsedMemory 
-        storage_allocated_gb = $Total_DriveSpaceGB 
-        storage_used_gb = $Total_UsedDriveSpaceGB 
-        cpu_count = $cpu_count
-        operating_system = $OSInfo.Caption 
+        host_name                = $cpu.SystemName
+        ram_allocated_gb         = $PhysicalMemory 
+        ram_used_gb              = $OSUsedMemory 
+        storage_allocated_gb     = $Total_DriveSpaceGB 
+        storage_used_gb          = $Total_UsedDriveSpaceGB 
+        cpu_count                = $cpu_count
+        operating_system         = $OSInfo.Caption 
         operating_system_version = $OSInfo.Version 
-        cpu_name = $cpu.Name 
+        cpu_name                 = $cpu.Name 
     }
 
     $custom_fields = New-Object -TypeName psobject -Property @{
-        CPU_Description = $cpu.Description 
-        CPU_Manufacturer = $cpu.Manufacturer 
-        CPU_L2CacheSize = $cpu.L2CacheSize 
-        CPU_L3CacheSize = $cpu.L3CacheSize 
-        CPU_SocketDesignation = $cpu.SocketDesignation 
+        CPU_Description        = $cpu.Description 
+        CPU_Manufacturer       = $cpu.Manufacturer 
+        CPU_L2CacheSize        = $cpu.L2CacheSize 
+        CPU_L3CacheSize        = $cpu.L3CacheSize 
+        CPU_SocketDesignation  = $cpu.SocketDesignation 
         TotalVisible_Memory_GB = $OSTotalVisibleMemory
         TotalVirtual_Memory_GB = $OSTotalVirtualMemory 
-        cpu_average = $CPUUtilization.Average
-        cpu_peak = $CPUUtilization.Maximum
-        cpu_sampling_timeout = $CPUUtilization.Count
+        cpu_average            = $CPUUtilization.Average
+        cpu_peak               = $CPUUtilization.Maximum
+        cpu_sampling_timeout   = $CPUUtilization.Count
     }
 
-    Add-Member -InputObject $server_info -MemberType NoteProperty -name "custom_fields" -value $custom_fields
+    Add-Member -InputObject $server_info -MemberType NoteProperty -Name "custom_fields" -Value $custom_fields
     # Add-Member -InputObject $server_info -MemberType NoteProperty -name "process_stats" -value $process_stats
     $server_info
 }


### PR DESCRIPTION
This PR introduces the following changes:

## Adds `-NoWinRM` parameter which allows connecting remote machines without WinRM enabled

CPU utilization feature relies on WinRM approach as for now, so this information is not available when `-NoWinRM` is specified.

## Adds `-ProcessStats` parameter to add process stats to the final output

Getting process statistics relies on WinRM approach, so this information is not available when `-NoWinRM` is specified.