### PR TITLE
Adding `--cpu-utilization-only-value` flag to Machine Stats for Unix-like Systems

### DIFF
--- a/unix/src/machine_stats/plugins/cpu_utilization.py
+++ b/unix/src/machine_stats/plugins/cpu_utilization.py
@@ -1,20 +1,32 @@
+import argparse
+
+
 def setup(app):
     timeout = app.args.cpu_utilization_timeout
+    only_value = app.args.cpu_utilization_only_value
     if timeout > 0:
         app.add_playbook_tasks(
             dict(
-                action=dict(module="cpu_utilization", args=dict(timeout=timeout)),
+                action=dict(
+                    module="cpu_utilization",
+                    args=dict(timeout=timeout, only_value=only_value),
+                ),
             )
         )
 
 
-def add_arguments(parser):
+def add_arguments(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--cpu-utilization-timeout",
         metavar="SECONDS",
         type=int,
         default=30,
         help="timeout sampling for CPU utilization",
+    )
+    parser.add_argument(
+        "--cpu-utilization-only-value",
+        action="store_true",
+        help="calculate only CPU utilization value and not peak and average values",
     )
 
 
@@ -23,13 +35,24 @@ def ok_callback(parent, result):
     cpu_sampling_timeout = result._result.get("timeout")
     cpu_util = result._result.get("ansible_cpu_utilization")
     if cpu_util is not None:
-        parent.update_results(
-            host,
-            {
-                "custom_fields": {
-                    "cpu_sampling_timeout": cpu_sampling_timeout,
-                    "cpu_average": cpu_util["average"],
-                    "cpu_peak": cpu_util["peak"],
-                }
-            },
-        )
+        if "value" in cpu_util:
+            parent.update_results(
+                host,
+                {
+                    "custom_fields": {
+                        "cpu_sampling_timeout": cpu_sampling_timeout,
+                        "cpu_utilization": cpu_util["value"],
+                    }
+                },
+            )
+        else:
+            parent.update_results(
+                host,
+                {
+                    "custom_fields": {
+                        "cpu_sampling_timeout": cpu_sampling_timeout,
+                        "cpu_average": cpu_util["average"],
+                        "cpu_peak": cpu_util["peak"],
+                    }
+                },
+            )


### PR DESCRIPTION
This PR introduces the following changes:

- Adds `--cpu-utilization-only-value` flag

Without that flag, Machine Stats will provide `peak` and `average` values for CPU utilization, with the flag set, it will only output the value:

```
machine_stats --cpu-utilization-only-value
{
    "servers": [
        {
            "cpu_count": 1,
            "cpu_name": "Intel(R) Xeon(R) CPU @ 2.30GHz",
            "custom_fields": {
                "cpu_sampling_timeout": 30,
                "cpu_utilization": 0.5
            },
            "fqdn": "nested-host.c.machine-stats-lab.internal",
            "host_name": "nested-host",
            "ip_addresses": [
                "192.168.122.1",
                "10.128.0.30",
                "fe80::4001:aff:fe80:1e"
            ],
            "operating_system": "Debian",
            "operating_system_version": "10",
            "ram_allocated_gb": 3.607421875,
            "ram_used_gb": 0.4765625,
            "storage_allocated_gb": 9.778318405151367,
            "storage_used_gb": 3.032133102416992
        }
    ]
}
```