### PR TITLE
fix(windows): change param type to bool

### DIFF
--- a/windows/server_stats.ps1
+++ b/windows/server_stats.ps1
@@ -12,8 +12,8 @@ $ServerStats = {
         $Credential,
 
         [Parameter()]
-        [switch]
-        $ProcessStats
+        [bool]
+        $ProcessStats=$false
     )
     $getWmiObjectParams = @{
         ComputerName  = $ComputerName


### PR DESCRIPTION
This PR introdoces the following changes:

1. Change script block `$ProcessStats` parameter type from `switch` to `bool`.
   Switch parameters are excluded from positional parameters by default, but `ArgumentList` passes only positional parameters to `ScriptBlock`'s of `Invoke-Command` or `Start-Job`.