### PR TITLE
CPU utilization timeout parameter

### DIFF
--- a/windows/runner.ps1
+++ b/windows/runner.ps1
@@ -25,6 +25,11 @@ Specifies if WinRM should not be used.
 
 Specifies if capturing process metrics should be enabled (WinRM only).
 
+.PARAMETER CpuUtilizationTimeout
+
+Specifies the number of seconds to measure CPU utilization.
+The default value is 30.
+
 .INPUTS
 
 None. You cannot pipe objects to runner.ps1
@@ -59,7 +64,11 @@ param (
 
     [Parameter()]
     [switch]
-    $ProcessStats
+    $ProcessStats,
+
+    [Parameter()]
+    [double]
+    $CpuUtilizationTimeout = 30
 )
 
 $securePwdFile = Join-Path -Path $PWD -ChildPath "SecuredText.txt"
@@ -97,7 +106,7 @@ $server_list | ForEach-Object {
     if ($NoWinRM -eq $tru) {
         $startJobParams = @{
             ScriptBlock  = $ServerStats
-            ArgumentList = $_, $cred, $ProcessStats
+            ArgumentList = $_, $cred, $ProcessStats, $CpuUtilizationTimeout
         }
         $jobs += Start-Job @startJobParams
     } else {
@@ -105,7 +114,7 @@ $server_list | ForEach-Object {
             ComputerName = $_
             Credential   = $cred
             ScriptBlock  = $ServerStats
-            ArgumentList = "localhost", $null, $ProcessStats
+            ArgumentList = "localhost", $null, $ProcessStats, $CpuUtilizationTimeout
         }
         $jobs += Invoke-Command @invokeCommandParams -AsJob
     }

--- a/windows/server_stats.ps1
+++ b/windows/server_stats.ps1
@@ -125,9 +125,6 @@ $ServerStats = {
         CPU_SocketDesignation  = $cpu.SocketDesignation 
         TotalVisible_Memory_GB = $OSTotalVisibleMemory
         TotalVirtual_Memory_GB = $OSTotalVirtualMemory 
-        cpu_average            = $CPUUtilization.Average
-        cpu_peak               = $CPUUtilization.Maximum
-        cpu_sampling_timeout   = $CPUUtilization.Count
     }
 
     if (!$remote) {

--- a/windows/server_stats.ps1
+++ b/windows/server_stats.ps1
@@ -13,7 +13,11 @@ $ServerStats = {
 
         [Parameter()]
         [bool]
-        $ProcessStats=$false
+        $ProcessStats=$false,
+
+        [Parameter()]
+        [double]
+        $CpuUtilizationTimeout
     )
     $getWmiObjectParams = @{
         ComputerName  = $ComputerName
@@ -67,7 +71,7 @@ $ServerStats = {
         $counter_params = @{
             Counter        = "\Processor(_Total)\% Processor Time"
             SampleInterval = 1
-            MaxSamples     = 30
+            MaxSamples     = $CpuUtilizationTimeout
         }
         $CPUUtilization = (Get-Counter @counter_params |
             Select-Object -ExpandProperty countersamples |


### PR DESCRIPTION
This PR introduces the following changes to Machine Stats for Windows:

1. Adds configurable `-CpuUtilizationTimeout` parameter
2. Fixes issue with CPU utilization custom fields and `MemberAlreadyExists` error