### PR TITLE
Skip process proc files if errors hit resolving path

### DIFF
--- a/unix/src/machine_stats/modules/proc_stats.py
+++ b/unix/src/machine_stats/modules/proc_stats.py
@@ -58,7 +58,12 @@ def parse_status(process_path):
     # Note : This call requires root level access to be able to follow
     # all symlinks. Otherwise some processes will be identified as
     # /proc/2138/exe
-    path, name = str(Path(process_path + "/exe").resolve()).rsplit("/", 1)
+
+    try:
+        path, name = str(Path(process_path + "/exe").resolve()).rsplit("/", 1)
+    except:
+        return stats
+
     stats["path"] = path
     stats["name"] = name
 
@@ -118,7 +123,7 @@ def process_stats():
     process_paths = [folder.path for folder in os.scandir("/proc") if
                      folder.is_dir() and str.isdigit(folder.name)]
 
-    return [parse_status(process) for process in process_paths]
+    return list(filter(None, [parse_status(process) for process in process_paths]))
 
 def main():
     run_module()


### PR DESCRIPTION
In some cases when the proc files deviate from the conventional unix file patterns and 'break', it can cause issues in machine stats to parse and return the running processes. (The 'error' thrown here about the sym link, is actually normal behaviour for 'files' in proc). This PR fixes that. Fix here is to catch all exceptions when resolving the file paths in `/proc` and ignore those files.

current:
![image](https://user-images.githubusercontent.com/6665997/153469458-e54f194c-db27-4fb8-9c73-ccd81f4e1cec.png)

new:
![image](https://user-images.githubusercontent.com/6665997/153469558-2f15851e-45a6-4148-ad52-053b4903cc2f.png)
