### PR TITLE
Correct version bump command in docs

### DIFF
--- a/unix/CONTRIBUTING.md
+++ b/unix/CONTRIBUTING.md
@@ -50,9 +50,9 @@ We use [`bump2version`](https://pypi.org/project/bump2version/) to update versio
 
 For example, if the current version in `1.0.0`:
 
-* `pipenv bump2version patch` will change the version to `1.0.1`
-* `pipenv bump2version minor` will change the version to `1.1.0`
-* `pipenv bump2version major` will change the version to `2.0.0`
+* `pipenv run bump2version patch` will change the version to `1.0.1`
+* `pipenv run bump2version minor` will change the version to `1.1.0`
+* `pipenv run bump2version major` will change the version to `2.0.0`
 
 After that all you need to do is to run
 


### PR DESCRIPTION
current command doc'd didn't work for me:
![image](https://user-images.githubusercontent.com/6665997/153496277-1ef7c56b-599c-4ee2-973d-7a038a86c615.png)

this PR corrects that doc.