### PR TITLE
Add CPU Utilization Timestamp

### DIFF
--- a/windows/runner.ps1
+++ b/windows/runner.ps1
@@ -30,6 +30,10 @@ Specifies if capturing process metrics should be enabled (WinRM only).
 Specifies the number of seconds to measure CPU utilization.
 The default value is 30.
 
+.PARAMETER CpuUtilizationOnlyValue
+
+Capture point-in-time CPU utilization value rather than a peak and average over a given time.
+
 .INPUTS
 
 None. You cannot pipe objects to runner.ps1

--- a/windows/server_stats.ps1
+++ b/windows/server_stats.ps1
@@ -81,8 +81,9 @@ $ServerStats = {
         Start-Sleep -Seconds $CpuUtilizationTimeout
         $perf += getPerf
 
-        $CPUUtilizationTimestamp_1 = $perf[0].TimeStamp_Sys100NS
-        $CPUUtilizationTimestamp_2 = $perf[1].TimeStamp_Sys100NS
+        # Convert start and end timestamps from LDAP time
+        $CPUUtilization_StartTimeStamp = w32tm.exe /ntte $perf[0].TimeStamp_Sys100NS
+        $CPUUtilization_EndTimeStamp = w32tm.exe /ntte $perf[1].TimeStamp_Sys100NS
 
         $pptDiff = $perf[1].PercentProcessorTime - $perf[0].PercentProcessorTime
         $tsDiff = $perf[1].TimeStamp_Sys100NS - $perf[0].TimeStamp_Sys100NS
@@ -151,8 +152,8 @@ $ServerStats = {
 
     if ($CpuUtilizationOnlyValue) {
         $custom_fields | Add-Member -NotePropertyName cpu_utilization -NotePropertyValue $CPUUtilization
-        $custom_fields | Add-Member -NotePropertyName cpu_utilization_timestamp_1 -NotePropertyValue $CPUUtilizationTimestamp_1
-        $custom_fields | Add-Member -NotePropertyName cpu_utilization_timestamp_2 -NotePropertyValue $CPUUtilizationTimestamp_2
+        $custom_fields | Add-Member -NotePropertyName cpu_utilization_start_timestamp -NotePropertyValue $CPUUtilization_StartTimestamp
+        $custom_fields | Add-Member -NotePropertyName cpu_utilization_end_timestamp -NotePropertyValue $CPUUtilization_EndTimestamp
     } else {
         if (!$remote) {
             $custom_fields | Add-Member -NotePropertyName cpu_average -NotePropertyValue $CPUUtilization.Average

--- a/windows/server_stats.ps1
+++ b/windows/server_stats.ps1
@@ -81,8 +81,8 @@ $ServerStats = {
         Start-Sleep -Seconds $CpuUtilizationTimeout
         $perf += getPerf
 
-        # Convert timestamp from LDAP time
-        $CPUUtilization_TimeStamp = w32tm.exe /ntte $perf[0].TimeStamp_Sys100NS
+        $TimestampRaw = $perf[0].TimeStamp_Sys100NS
+        $CPUUtilizationTimestamp = [DateTime]::FromFileTimeUtc($TimestampRaw).ToString("yyyy-MM-dd hh:mm:ss")
 
         $pptDiff = $perf[1].PercentProcessorTime - $perf[0].PercentProcessorTime
         $tsDiff = $perf[1].TimeStamp_Sys100NS - $perf[0].TimeStamp_Sys100NS
@@ -151,7 +151,7 @@ $ServerStats = {
 
     if ($CpuUtilizationOnlyValue) {
         $custom_fields | Add-Member -NotePropertyName cpu_utilization -NotePropertyValue $CPUUtilization
-        $custom_fields | Add-Member -NotePropertyName cpu_utilization_timestamp -NotePropertyValue $CPUUtilization_Timestamp
+        $custom_fields | Add-Member -NotePropertyName cpu_utilization_timestamp -NotePropertyValue $CPUUtilizationTimestamp
     } else {
         if (!$remote) {
             $custom_fields | Add-Member -NotePropertyName cpu_average -NotePropertyValue $CPUUtilization.Average

--- a/windows/server_stats.ps1
+++ b/windows/server_stats.ps1
@@ -81,9 +81,8 @@ $ServerStats = {
         Start-Sleep -Seconds $CpuUtilizationTimeout
         $perf += getPerf
 
-        # Convert start and end timestamps from LDAP time
-        $CPUUtilization_StartTimeStamp = w32tm.exe /ntte $perf[0].TimeStamp_Sys100NS
-        $CPUUtilization_EndTimeStamp = w32tm.exe /ntte $perf[1].TimeStamp_Sys100NS
+        # Convert timestamp from LDAP time
+        $CPUUtilization_TimeStamp = w32tm.exe /ntte $perf[0].TimeStamp_Sys100NS
 
         $pptDiff = $perf[1].PercentProcessorTime - $perf[0].PercentProcessorTime
         $tsDiff = $perf[1].TimeStamp_Sys100NS - $perf[0].TimeStamp_Sys100NS
@@ -152,8 +151,7 @@ $ServerStats = {
 
     if ($CpuUtilizationOnlyValue) {
         $custom_fields | Add-Member -NotePropertyName cpu_utilization -NotePropertyValue $CPUUtilization
-        $custom_fields | Add-Member -NotePropertyName cpu_utilization_start_timestamp -NotePropertyValue $CPUUtilization_StartTimestamp
-        $custom_fields | Add-Member -NotePropertyName cpu_utilization_end_timestamp -NotePropertyValue $CPUUtilization_EndTimestamp
+        $custom_fields | Add-Member -NotePropertyName cpu_utilization_timestamp -NotePropertyValue $CPUUtilization_Timestamp
     } else {
         if (!$remote) {
             $custom_fields | Add-Member -NotePropertyName cpu_average -NotePropertyValue $CPUUtilization.Average

--- a/windows/server_stats.ps1
+++ b/windows/server_stats.ps1
@@ -80,6 +80,10 @@ $ServerStats = {
         $perf = @(getPerf)
         Start-Sleep -Seconds $CpuUtilizationTimeout
         $perf += getPerf
+
+        $CPUUtilizationTimestamp_1 = $perf[0].TimeStamp_Sys100NS
+        $CPUUtilizationTimestamp_2 = $perf[1].TimeStamp_Sys100NS
+
         $pptDiff = $perf[1].PercentProcessorTime - $perf[0].PercentProcessorTime
         $tsDiff = $perf[1].TimeStamp_Sys100NS - $perf[0].TimeStamp_Sys100NS
         $CPUUtilization = (1 - $pptDiff / $tsDiff) * 100
@@ -147,6 +151,8 @@ $ServerStats = {
 
     if ($CpuUtilizationOnlyValue) {
         $custom_fields | Add-Member -NotePropertyName cpu_utilization -NotePropertyValue $CPUUtilization
+        $custom_fields | Add-Member -NotePropertyName cpu_utilization_timestamp_1 -NotePropertyValue $CPUUtilizationTimestamp_1
+        $custom_fields | Add-Member -NotePropertyName cpu_utilization_timestamp_2 -NotePropertyValue $CPUUtilizationTimestamp_2
     } else {
         if (!$remote) {
             $custom_fields | Add-Member -NotePropertyName cpu_average -NotePropertyValue $CPUUtilization.Average


### PR DESCRIPTION
Added a timestamp to the output when using the `-CPUUtilizationOnlyValue` flag. 

When using this flag MS4W will take 2 readings, spaced out by the amount of time specified in the `-CpuUtilizationTimeout` flag. The result is the average of these two readings. To calculate this average, the property `TimeStamp_Sys100NS` is read from the subject machine in LDAP time. 

This PR adds the first of these values to the output, converted into a human readable format. The intention is to allow us to get the closest possible time to when CPU utilization is read. 

The name of the custom field and the format of the timestamp are exactly the same as the equivalent in machine stats for Unix. The timestamp is always UTC regardless of the timezone of the controller or subject machines.

Here's a sample reading:

```
{
    "servers":  [
                    {
                        "operating_system":  "Microsoft Windows Server 2019 Datacenter",
                        "storage_used_gb":  18,
                        "ram_used_gb":  1.35,
                        "operating_system_version":  "10.0.17763",
                        "cpu_name":  "Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz",
                        "storage_allocated_gb":  30,
                        "cpu_count":  1,
                        "host_name":  "EC2AMAZ-PDB4QNM",
                        "ram_allocated_gb":  2,
                        "custom_fields":  {
                                              "CPU_SocketDesignation":  "CPU 0",
                                              "CPU_Manufacturer":  "GenuineIntel",
                                              "CPU_Description":  "Intel64 Family 6 Model 85 Stepping 4",
                                              "CPU_L3CacheSize":  33792,
                                              "CPU_L2CacheSize":  24576,
                                              "TotalVirtual_Memory_GB":  3.09,
                                              "TotalVisible_Memory_GB":  1.96,
                                              "cpu_utilization":  0.76991469351103126,
                                              "cpu_utilization_timestamp":  "2022-04-11 11:49:42"
                                          },
                        "PSComputerName":  "ec2-13-229-127-193.ap-southeast-1.compute.amazonaws.com",
                        "RunspaceId":  "1603410f-018e-4de8-9561-83d8cabe06ac",
                        "PSShowComputerName":  true
                    }
                ]
}
```