### PR TITLE
Add linting for PowerShell scripts

### DIFF
--- a/.github/workflows/prechecks.yml
+++ b/.github/workflows/prechecks.yml
@@ -1,0 +1,39 @@
+name: "Prechecks"
+
+on:
+  push:
+    branches: [ master, pranav/ps-lint ]
+    paths-ignore:
+      - "*.md"
+  pull_request:
+    branches: [ master ]
+    paths-ignore:
+      - "*.md"
+
+jobs:
+  windows:
+    name: Windows prechecks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # Find more information on the PSScriptAnalyzer at
+      # https://github.com/PowerShell/PSScriptAnalyzer
+      - name: Install PSScriptAnalyzer module
+        shell: pwsh
+        run: |
+          Set-PSRepository PSGallery -InstallationPolicy Trusted
+          Install-Module PSScriptAnalyzer -ErrorAction Stop
+      
+      - name: Lint with PSScriptAnalyzer
+        working-directory: windows
+        shell: pwsh
+        run: |
+          Invoke-ScriptAnalyzer -Path *.ps1 -Recurse -Outvariable issues
+          $errors   = $issues.Where({$_.Severity -eq 'Error'})
+          $warnings = $issues.Where({$_.Severity -eq 'Warning'})
+          if ($errors) {
+              Write-Error "There were $($errors.Count) errors and $($warnings.Count) warnings total." -ErrorAction Stop
+          } else {
+              Write-Output "There were $($errors.Count) errors and $($warnings.Count) warnings total."
+          }

--- a/.github/workflows/prechecks.yml
+++ b/.github/workflows/prechecks.yml
@@ -2,7 +2,7 @@ name: "Prechecks"
 
 on:
   push:
-    branches: [ master, pranav/ps-lint ]
+    branches: [ master ]
     paths-ignore:
       - "*.md"
   pull_request:

--- a/unix/CONTRIBUTING.md
+++ b/unix/CONTRIBUTING.md
@@ -4,8 +4,7 @@ Welcome! Happy to see you willing to make the project better.
 
 ## We're standing on the shoulders of giants
 
-Under the hood Machine Stats relies on the awesome [Ansible
-SDK](https://docs.ansible.com/ansible/latest/dev_guide/index.html).
+Under the hood Machine Stats relies on the awesome [Ansible SDK](https://docs.ansible.com/ansible/latest/dev_guide/index.html).
 
 ## Technicalities
 


### PR DESCRIPTION
This PR adds a linter [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) for all the PowerShell scripts in the `windows` folder.