### PR TITLE
adjust proc-status line splitting

### DIFF
--- a/unix/src/machine_stats/modules/proc_stats.py
+++ b/unix/src/machine_stats/modules/proc_stats.py
@@ -92,9 +92,11 @@ def parse_status(process_path):
     status = dict()
     with open(process_path + "/status") as proc_status:
         for line in proc_status:
-            name, value = line.split(":")
-            name = name.lower().strip()
-            status[name] = value.strip()
+            result = line.split(":")
+            name = result[0].lower().strip()
+            value = result[1].strip()
+
+            status[name] = value
 
     # Parse error will throw to parent function
     if status.get("pid"):


### PR DESCRIPTION
### Changes

This PR adjusts the way we split the content when reading proc_stats. The current implementation is impacting some users.
 