### PR TITLE
MS4W: Fix hard-coded paths

### DIFF
--- a/windows/runner.ps1
+++ b/windows/runner.ps1
@@ -80,7 +80,7 @@ param (
 
     [Parameter()]
     [switch]
-    $CpuUtilizationOnlyValue    
+    $CpuUtilizationOnlyValue
 )
 
 if (![System.IO.File]::Exists($SecurePwdFilePath)) {


### PR DESCRIPTION
Added 2 new parameters to the MS4W `runner.ps1` script, which allows the user to specify the location of the password file and the `server_stats.ps1` script block. 

These are 
- `SecurePwdFilePath`
- `ServerStatsPath`

Previously these were hard-coded to only look in the current directory, which would work when running MS4W from its directory but would fail when running in a scheduled job since these are not invoked from that directory.

When these parameters are not specified, they default to the current directory, maintaining the original behaviour.

For a full rundown on how to run MS4W in a scheduled job, check out [this document](https://docs.google.com/document/d/1-njAnGHf4R0LLXUgu19_oUDNuUlIDoRGUkMcTH4zczc/edit?usp=sharing).