### PR TITLE
Fix -NoWinRM flag

### DIFF
--- a/windows/runner.ps1
+++ b/windows/runner.ps1
@@ -118,7 +118,7 @@ $server_list | ForEach-Object {
     if ($NoWinRM -eq $tru) {
         $startJobParams = @{
             ScriptBlock  = $ServerStats
-            ArgumentList = $_, $cred, $ProcessStats, $CpuUtilizationTimeout, $CpuUtilizationOnlyValue
+            ArgumentList = $_, $cred, $ProcessStats, $CpuUtilizationTimeout, $CpuUtilizationOnlyValue, $NoWinRM
         }
         $jobs += Start-Job @startJobParams
     } else {
@@ -126,7 +126,7 @@ $server_list | ForEach-Object {
             ComputerName = $_
             Credential   = $cred
             ScriptBlock  = $ServerStats
-            ArgumentList = "localhost", $null, $ProcessStats, $CpuUtilizationTimeout, $CpuUtilizationOnlyValue
+            ArgumentList = "localhost", $null, $ProcessStats, $CpuUtilizationTimeout, $CpuUtilizationOnlyValue, $NoWinRM
         }
         $jobs += Invoke-Command @invokeCommandParams -AsJob
     }

--- a/windows/runner.ps1
+++ b/windows/runner.ps1
@@ -115,7 +115,7 @@ $server_stats = @()
 $jobs = @()
 
 $server_list | ForEach-Object {
-    if ($NoWinRM -eq $tru) {
+    if ($NoWinRM) {
         $startJobParams = @{
             ScriptBlock  = $ServerStats
             ArgumentList = $_, $cred, $ProcessStats, $CpuUtilizationTimeout, $CpuUtilizationOnlyValue, $NoWinRM

--- a/windows/server_stats.ps1
+++ b/windows/server_stats.ps1
@@ -21,18 +21,23 @@ $ServerStats = {
 
         [Parameter()]
         [bool]
-        $CpuUtilizationOnlyValue=$false
+        $CpuUtilizationOnlyValue=$false,
+
+        [Parameter()]
+        [bool]
+        $NoWinRM
     )
+
     $getWmiObjectParams = @{
         ComputerName  = $ComputerName
         Namespace     = "ROOT\cimv2"
         Impersonation = 3 # Impersonate. Allows objects to use the credentials of the caller.
     }
-    # If $remote is $true, it means that -NoWinRM parameter was set.
-    $remote = $ComputerName -notin ".", "localhost", ([System.Environment]::MachineName)
-    if ($remote) {
+
+    if ($NoWinRM) {
         $getWmiObjectParams | Add-Member -NotePropertyName Credential -NotePropertyValue $Credential
     }
+
     # Helper Functions for aggregating process information
     $memory_used_mb = { [math]::Round(($_.WorkingSet64 / 1MB), 2) }
     $max_memory_used_mb = { [math]::Round(($_.PeakWorkingSet64 / 1MB), 2) }
@@ -47,6 +52,7 @@ $ServerStats = {
     } else {
         $cpu = $CPUInfo
     }
+
     $cpu_count = Get-WmiObject Win32_Processor @getWmiObjectParams |
     Measure-Object -Property NumberOfCores -Sum |
     Select-Object -ExpandProperty Sum
@@ -88,7 +94,7 @@ $ServerStats = {
         $tsDiff = $perf[1].TimeStamp_Sys100NS - $perf[0].TimeStamp_Sys100NS
         $CPUUtilization = (1 - $pptDiff / $tsDiff) * 100
     } else { # Get peak and average
-        if (!$remote) { # CPU utilization requires WinRM
+        if (!$NoWinRM) { # CPU utilization requires WinRM
             $counter_params = @{
                 Counter        = "\Processor(_Total)\% Processor Time"
                 SampleInterval = 1
@@ -102,7 +108,7 @@ $ServerStats = {
     }
 
     $process_stats = $null
-    if ($ProcessStats -and !$remote) {
+    if ($ProcessStats -and !$NoWinRM) {
         # WinRM is required for process stats
         if ($is_admin) {
             # Get Information on current running processes
@@ -153,7 +159,7 @@ $ServerStats = {
         $custom_fields | Add-Member -NotePropertyName cpu_utilization -NotePropertyValue $CPUUtilization
         $custom_fields | Add-Member -NotePropertyName cpu_utilization_timestamp -NotePropertyValue $CPUUtilizationTimestamp
     } else {
-        if (!$remote) {
+        if (!$NoWinRM) {
             $custom_fields | Add-Member -NotePropertyName cpu_average -NotePropertyValue $CPUUtilization.Average
             $custom_fields | Add-Member -NotePropertyName cpu_peak -NotePropertyValue $CPUUtilization.Maximum
             $custom_fields | Add-Member -NotePropertyName cpu_sampling_timeout -NotePropertyValue $CPUUtilization.Count


### PR DESCRIPTION
Previously, the logic to read a subject machine with WMI was never used because of an incorrect if clause. This clause would always equate to false because of a typo, and it was only possible to use the WinRM logic.

This PR also passes the `NoWinRM` bool to `server_stats` directly. Previously, there was logic in `server_stats` that tried to ascertain whether we're using the `-NoWinRM` flag by checking that the current computer is not 'localhost' or the had the same hostname as what's being operated on from the `servers.txt` file. 

As this file can take many values (private IP, full DNS address, etc), this logic is unreliable, and it makes more sense that we can tell whether or not we're using the `-NoWinRM` option by simply passing this same option in as an argument to the script block.

As of these changes, it's now possible to run `-NoWinRM` and MS4W will use WMI. There are some caveats to this and proper documentation will follow. 