### PR TITLE
Ubuntu: Check dependencies installation and machine stats' test run

### DIFF
--- a/.github/workflows/prechecks-unix.yml
+++ b/.github/workflows/prechecks-unix.yml
@@ -1,0 +1,37 @@
+name: "Prechecks Unix"
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - unix
+    paths-ignore:
+      - "*.md"
+  pull_request:
+    branches: [ master ]
+    paths:
+      - unix
+    paths-ignore:
+      - "*.md"
+
+jobs:
+  unix:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+    name: Unix prechecks - Python ${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+
+      - name: Install flake8
+        run: pip install flake8
+
+      - name: Run flake8 linter
+        working-directory: unix
+        run: flake8 ./src --config ./setup.cfg

--- a/.github/workflows/prechecks-unix.yml
+++ b/.github/workflows/prechecks-unix.yml
@@ -28,10 +28,26 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
+      
+      - name: Install pipenv
+        run: |
+          python -m pip install --upgrade pipenv wheel
 
       - name: Install flake8
         run: pip install flake8
 
+      ## Check linting ##
       - name: Run flake8 linter
         working-directory: unix
         run: flake8 ./src --config ./setup.cfg
+      
+      ## Check packaging ##
+      - name: Install dependencies
+        working-directory: unix
+        run: |
+          pipenv install --deploy --dev --verbose
+      
+      - name: Run machine stats
+        working-directory: unix
+        run: |
+          pipenv run machine-stats -h

--- a/.github/workflows/prechecks-unix.yml
+++ b/.github/workflows/prechecks-unix.yml
@@ -2,17 +2,13 @@ name: "Prechecks Unix"
 
 on:
   push:
-    branches: [ master, pranav/prechecks ]
-    paths:
-      - unix
-    paths-ignore:
-      - "*.md"
+    branches: pranav/prechecks
   pull_request:
     branches: [ master ]
-    paths:
-      - unix
     paths-ignore:
       - "*.md"
+      - "windows/**"
+      - "libvirt/**"
 
 jobs:
   unix:

--- a/.github/workflows/prechecks-unix.yml
+++ b/.github/workflows/prechecks-unix.yml
@@ -24,10 +24,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-      
+
       - name: Install pipenv
-        run: |
-          python -m pip install --upgrade pipenv wheel
+        run: python -m pip install --upgrade pipenv wheel
 
       - name: Install flake8
         run: pip install flake8
@@ -36,14 +35,12 @@ jobs:
       - name: Run flake8 linter
         working-directory: unix
         run: flake8 ./src --config ./setup.cfg
-      
+
       ## Check packaging ##
       - name: Install dependencies
         working-directory: unix
-        run: |
-          pipenv install --deploy --dev --verbose
-      
+        run: pipenv install --deploy
+
       - name: Run machine stats
         working-directory: unix
-        run: |
-          pipenv run machine-stats -h
+        run: pipenv run machine-stats -h

--- a/.github/workflows/prechecks-unix.yml
+++ b/.github/workflows/prechecks-unix.yml
@@ -1,8 +1,6 @@
 name: "Prechecks Unix"
 
 on:
-  push:
-    branches: pranav/prechecks
   pull_request:
     branches: [ master ]
     paths-ignore:

--- a/.github/workflows/prechecks-unix.yml
+++ b/.github/workflows/prechecks-unix.yml
@@ -2,7 +2,7 @@ name: "Prechecks Unix"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, pranav/prechecks ]
     paths:
       - unix
     paths-ignore:

--- a/.github/workflows/prechecks-windows.yml
+++ b/.github/workflows/prechecks-windows.yml
@@ -1,18 +1,12 @@
 name: "Prechecks Windows"
 
 on:
-  push:
-    branches: [ master ]
-    paths:
-      - windows
-    paths-ignore:
-      - "*.md"
   pull_request:
     branches: [ master ]
-    paths:
-      - windows
     paths-ignore:
       - "*.md"
+      - "unix/**"
+      - "libvirt/**"
 
 jobs:
   windows:

--- a/.github/workflows/prechecks-windows.yml
+++ b/.github/workflows/prechecks-windows.yml
@@ -1,38 +1,20 @@
-name: "Prechecks"
+name: "Prechecks Windows"
 
 on:
   push:
     branches: [ master ]
+    paths:
+      - windows
     paths-ignore:
       - "*.md"
   pull_request:
     branches: [ master ]
+    paths:
+      - windows
     paths-ignore:
       - "*.md"
 
 jobs:
-  unix:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
-    name: Unix prechecks - Python ${{ matrix.python-version }}
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-python@v3
-        with:
-          python-version: ${{ matrix.python-version }}
-          architecture: x64
-
-      - name: Install flake8
-        run: pip install flake8
-
-      - name: Run flake8 linter
-        working-directory: unix
-        run: flake8 ./src --config ./setup.cfg
-
-
   windows:
     name: Windows prechecks
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR separates the prechecks workflow for Unix and Windows with an updated trigger to only fire up the workflow if the changes are in the relevant folder. It also checks if all the dependencies can be installed with a successful test run of machine stats. This will help us validate changes from dependabot without even running machine stats locally with the new dependencies.
