### PR TITLE
Add default and advanced prechecks workflows for Unix

### DIFF
--- a/.github/workflows/advanced-prechecks-unix.yml
+++ b/.github/workflows/advanced-prechecks-unix.yml
@@ -28,14 +28,6 @@ jobs:
       - name: Install pipenv
         run: python -m pip install --upgrade pipenv wheel
 
-      - name: Install flake8
-        run: pip install flake8
-
-      ## Check linting ##
-      - name: Run flake8 linter
-        working-directory: unix
-        run: flake8 ./src --config ./setup.cfg
-
       ## Check packaging ##
       - name: Install dependencies
         working-directory: unix

--- a/.github/workflows/default-prechecks-unix.yml
+++ b/.github/workflows/default-prechecks-unix.yml
@@ -1,0 +1,32 @@
+name: "Default Prechecks Unix"
+
+on:
+  pull_request:
+    branches: [ master ]
+    paths-ignore:
+      - "*.md"
+      - "!unix/**"
+      - "unix/prechecks/**"
+
+jobs:
+  ubuntu:
+    runs-on: ubuntu-latest
+    name: Ubuntu Default Prechecks
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.8
+          architecture: x64
+
+      - name: Install pipenv
+        run: python -m pip install --upgrade pipenv wheel
+
+      - name: Install flake8
+        run: pip install flake8
+
+      ## Check linting ##
+      - name: Run flake8 linter
+        working-directory: unix
+        run: flake8 ./src --config ./setup.cfg

--- a/.github/workflows/prechecks-unix.yml
+++ b/.github/workflows/prechecks-unix.yml
@@ -1,17 +1,18 @@
-name: "Prechecks Unix"
+name: "Advanced Prechecks Unix"
 
 on:
   pull_request:
     branches: [ master ]
+    types: [ labeled ]
     paths-ignore:
       - "*.md"
-      - "windows/**"
-      - "libvirt/**"
+      - "!unix/**"
       - "unix/prechecks/**"
 
 jobs:
   ubuntu:
     runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'ci' }}
     strategy:
       matrix:
         python-version: [ '3.7', '3.8', '3.9', '3.10' ]
@@ -46,6 +47,7 @@ jobs:
 
   rhel:
     runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'ci' }}
     strategy:
       matrix:
         python-version: [ '3.6', '3.8', '3.9', '3.10' ]

--- a/.github/workflows/prechecks-windows.yml
+++ b/.github/workflows/prechecks-windows.yml
@@ -5,8 +5,7 @@ on:
     branches: [ master ]
     paths-ignore:
       - "*.md"
-      - "unix/**"
-      - "libvirt/**"
+      - "!windows/**"
 
 jobs:
   windows:

--- a/unix/CONTRIBUTING.md
+++ b/unix/CONTRIBUTING.md
@@ -55,7 +55,7 @@ For example, if the current version in `1.0.0`:
 
 After that all you need to do is to run
 
-```sh
+```console
 git push origin master
 git push origin --tags
 ```

--- a/unix/CONTRIBUTING.md
+++ b/unix/CONTRIBUTING.md
@@ -14,7 +14,7 @@ it's 3.9.  You can use any operating system.
 Install all development dependencies using:
 
 ```console
-$ pipenv install --dev
+pipenv install --dev
 ```
 
 If you haven't used `pipenv` before but are comfortable with virtualenvs, just
@@ -28,9 +28,9 @@ run `pipenv run machine_stats` to run it locally.
 Non `pipenv` install works too:
 
 ```console
-$ pip install -r requirements.txt
-$ pip install -r dev-requirements.txt
-$ pip install -e .
+pip install -r requirements.txt
+pip install -r dev-requirements.txt
+pip install -e .
 ```
 
 ### Tools
@@ -55,7 +55,7 @@ For example, if the current version in `1.0.0`:
 
 After that all you need to do is to run
 
-```
+```sh
 git push origin master
 git push origin --tags
 ```
@@ -63,6 +63,14 @@ git push origin --tags
 This will update the version and trigger the PyPI build and deploy.
 
 _Note_: You can verify that the version has been updated after running the `bump2version` command by checking the `config.cfg` file. (current_version)
+
+### Introducing breaking changes?
+
+When you create a PR, the GitHub workflows check for the linting and CodeQL. However, if you think you're introducing breaking changes, then please add the label `ci` with your PR. This will run the Advanced Prechecks workflow that checks Machine Stats' working in the following system environments:
+
+* Ubuntu 20.04 - Python 3.7 to 3.10
+* RHEL 8 - Python 3.6, 3.8 to 3.10
+
 ## Finally
 
 Thanks again for your interest in improving the project! You're taking action


### PR DESCRIPTION
The prechecks workflow for Unix was set to trigger on ANY pull request. This can cause multiple runs of the workflow because it can also get triggered by adding more commits in an open PR. The workflow checked linting and ran machine stats' to see it's working in Ubuntu and RHEL for Python version 3.6 to 3.10. The latter part takes of the workflow takes a while to finish the execution**.

Since we will only want to run the latter part of the workflow with PRs where we think it might be introducing breaking changes (i.e., upgrading ansible version), this PR separates the workflow in 2
- Default prechecks: Checks linting
- Advanced prechecks: Runs machine stats for Ubuntu and RHEL

With the changes in this PR, the default precheck will run as usual but **to run the advanced workflow, you will have to add the ci label with the PR**.

**Workflows are for 5 different Python versions for Ubuntu and RHEL OSes.
- RHEL takes: 10-15 minutes X 5 = 50-75 GitHub runner minutes
- Ubuntu takes: 1-2 minutes X 5 = 5-10 GitHub runner minutes