### PR TITLE
Catch error reading local user with WinRM

### DIFF
--- a/windows/runner.ps1
+++ b/windows/runner.ps1
@@ -97,8 +97,13 @@ if (![System.IO.File]::Exists($SecurePwdFilePath)) {
 $secPwd = Get-Content $SecurePwdFilePath | ConvertTo-SecureString
 $cred = New-Object System.Management.Automation.PSCredential -ArgumentList $UserName, $secPwd
 
-$env_user = Invoke-Command -ComputerName ([Environment]::MachineName) -Credential $cred -ScriptBlock { $env:USERNAME }
-Write-Host "About to execute inventory gathering as user: $env_user"
+try {
+    $env_user = Invoke-Command -ComputerName ([Environment]::MachineName) -Credential $cred -ScriptBlock { $env:USERNAME } -ErrorAction Stop 
+    Write-Host "Executing inventory gathering as user: $env_user..."
+} catch [System.Management.Automation.Remoting.PSRemotingTransportException] {
+    Write-Host "Executing inventory gathering..."
+}
+
 
 # Load the ScriptBlock $ServerStats:
 . $ServerStatsPath

--- a/windows/runner.ps1
+++ b/windows/runner.ps1
@@ -104,7 +104,6 @@ try {
     Write-Host "Executing inventory gathering..."
 }
 
-
 # Load the ScriptBlock $ServerStats:
 . $ServerStatsPath
 


### PR DESCRIPTION
Before attempting to read the user's server inventory, MS4W will attempt to `Invoke-Command` (WinRM) on the local machine, using the credentials provided for the subject machines, to get the name of the current user. This name is then printed to the console and isn't used anywhere else.

If you're working on a controller machine that doesn't have the same credentials as your subject machines, Invoke-Command will log an error message to the console before continuing on to successfully read your servers. This is confusing behavior.

![image](https://user-images.githubusercontent.com/43866616/163999255-15fdb3f2-1af2-40a3-92bf-99f1ab6a873b.png)

This PR wraps this logic in a try-catch and catches the specific error thrown in this case. An alternative would be to remove the logic entirely, as this behavior doesn't mirror MS4U and is arguably unneccessary. 
