### PR TITLE
Replaced incorrect quotation characters in ProcessStats logic

### DIFF
--- a/windows/server_stats.ps1
+++ b/windows/server_stats.ps1
@@ -114,21 +114,21 @@ $ServerStats = {
             # Get Information on current running processes
             # IncludeUserName means we need admin priveleges
             $process_stats = Get-Process -IncludeUserName |
-            Select-Object -Property @{Name = ’user’; Expression = { $_.UserName } },
-            @{Name = ’name’; Expression = { $_.ProcessName } },
-            @{Name = ’path’; Expression = { $_.Path } },
-            @{Name = ’pid’; Expression = { $_.Id } },
-            @{Name = ’memory_used_mb’; Expression = $memory_used_mb },
-            @{Name = ’max_memory_used_mb’; Expression = $max_memory_used_mb },
-            @{Name = ’total_alive_time’; Expression = $process_alive_time }
+            Select-Object -Property @{Name = 'user'; Expression = { $_.UserName } },
+            @{Name = 'name'; Expression = { $_.ProcessName } },
+            @{Name = 'path'; Expression = { $_.Path } },
+            @{Name = 'pid'; Expression = { $_.Id } },
+            @{Name = 'memory_used_mb'; Expression = $memory_used_mb },
+            @{Name = 'max_memory_used_mb'; Expression = $max_memory_used_mb },
+            @{Name = 'total_alive_time'; Expression = $process_alive_time }
         } else {
             $process_stats = Get-Process |
-            Select-Object -Property @{Name = ’name’; Expression = { $_.ProcessName } },
-            @{Name = ’path’; Expression = { $_.Path } },
-            @{Name = ’pid’; Expression = { $_.Id } },
-            @{Name = ’memory_used_mb’; Expression = $memory_used_mb },
-            @{Name = ’max_memory_used_mb’; Expression = $max_memory_used_mb },
-            @{Name = ’total_alive_time’; Expression = $process_alive_time }
+            Select-Object -Property @{Name = 'name'; Expression = { $_.ProcessName } },
+            @{Name = 'path'; Expression = { $_.Path } },
+            @{Name = 'pid'; Expression = { $_.Id } },
+            @{Name = 'memory_used_mb'; Expression = $memory_used_mb },
+            @{Name = 'max_memory_used_mb'; Expression = $max_memory_used_mb },
+            @{Name = 'total_alive_time'; Expression = $process_alive_time }
         }
     }
 


### PR DESCRIPTION
The logic which runs when the `-ProcessStats` flag is used contained invalid single quote characters. This lead to errors like this:

![image](https://user-images.githubusercontent.com/43866616/164031683-221f0300-c4bf-4598-a7f1-03cdacf94725.png)

This PR simply swaps them out for the correct characters, and the feature works normally.

![image](https://user-images.githubusercontent.com/43866616/164031845-e81ffefc-fefe-407f-9ce1-beeb9025b450.png)

This resolves #194 .
