### PR TITLE
Release Machine Stats main using tags

### DIFF
--- a/.github/workflows/pypi-upload.yml
+++ b/.github/workflows/pypi-upload.yml
@@ -70,6 +70,19 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v2
+      
+      - name: Autobump version
+        run: |
+          # from refs/tags/v1.2.3 get 1.2.3
+          VERSION=${GITHUB_REF/refs\/tags\//}
+          PLACEHOLDER='version="develop"'
+          VERSION_FILE='setup.py'
+
+          # grep ensures the placeholder is there. If grep doesn't find the placeholder
+          # it exits with exit code 1 and github actions aborts the build. 
+          grep "$PLACEHOLDER" "$VERSION_FILE"
+          
+          sed -i "s/$PLACEHOLDER/version=\"${VERSION}\"/g" "$VERSION_FILE"
 
       - name: Install pypa/build and twine
         run: |

--- a/.github/workflows/pypi-upload.yml
+++ b/.github/workflows/pypi-upload.yml
@@ -1,10 +1,8 @@
 name: PyPI Upload
 
 on:
-  push:
-    branches: [ master ]
-    tags:
-      - '*'
+  release:
+    types: [ created ]
 
 jobs:
   machine_stats:

--- a/.github/workflows/pypi-upload.yml
+++ b/.github/workflows/pypi-upload.yml
@@ -17,8 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.8
+          architecture: x64
 
       - name: Autobump version
         run: |
@@ -68,8 +70,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.8
+          architecture: x64
       
       - name: Autobump version
         run: |

--- a/.github/workflows/pypi-upload.yml
+++ b/.github/workflows/pypi-upload.yml
@@ -2,6 +2,7 @@ name: PyPI Upload
 
 on:
   push:
+    branches: [ master ]
     tags:
       - '*'
 
@@ -18,6 +19,19 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v2
+
+      - name: Autobump version
+        run: |
+          # from refs/tags/v1.2.3 get 1.2.3
+          VERSION=${GITHUB_REF/refs\/tags\//}
+          PLACEHOLDER='version="develop"'
+          VERSION_FILE='setup.py'
+
+          # grep ensures the placeholder is there. If grep doesn't find the placeholder
+          # it exits with exit code 1 and github actions aborts the build. 
+          grep "$PLACEHOLDER" "$VERSION_FILE"
+          
+          sed -i "s/$PLACEHOLDER/version=\"${VERSION}\"/g" "$VERSION_FILE"
 
       - name: Install pypa/build and twine
         run: |

--- a/libvirt/CONTRIBUTING.md
+++ b/libvirt/CONTRIBUTING.md
@@ -85,9 +85,14 @@ We use the following tools:
 
 ### How to bump libvirt's version
 
-We use tags to release a new version of libvirt.
-To make a new release, simply create a tag on the `master` branch and the
-`pypi-upload` GitHub Workflow will take care of the rest.
+We use tags to release a new version of libvirt. To make a new release, simply create a tag on the `master` branch and the `pypi-upload` GitHub Workflow will take care of the rest.
+
+To build a new image, you will need to create a release. The steps are pretty simple, You can find Github's instruction [here](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release).
+
+* On the repo page, click on release (right side bar).
+* Create new release.
+* Choose a tag. You should create a new tag for your build. Make sure that you've selected the `master` branch as your target branch.
+* Publish the release.
 
 ## Finally
 

--- a/libvirt/CONTRIBUTING.md
+++ b/libvirt/CONTRIBUTING.md
@@ -83,6 +83,12 @@ We use the following tools:
        1    debian10   running
       ```
 
+### How to bump libvirt's version
+
+We use tags to release a new version of libvirt.
+To make a new release, simply create a tag on the `master` branch and the
+`pypi-upload` GitHub Workflow will take care of the rest.
+
 ## Finally
 
 Thanks again for your interest in improving the project! You're taking action

--- a/libvirt/setup.cfg
+++ b/libvirt/setup.cfg
@@ -1,8 +1,3 @@
-[bumpversion]
-current_version = 2.2.0
-commit = True
-tag = True
-
 [flake8]
 ignore = E203, E266, E501, W503
 max-line-length = 88
@@ -15,7 +10,3 @@ include_trailing_comma = True
 force_grid_wrap = 0
 use_parentheses = True
 line_length = 88
-
-[bumpversion:file:setup.py]
-
-[bumpversion:file:../unix/setup.py]

--- a/libvirt/setup.py
+++ b/libvirt/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="virt_stats",
-    version="2.5.4",
+    version="develop",
     author="Tidal Migrations",
     author_email="support@tidalmigrations.com",
     description="A simple and effective way to gather machine statistics (RAM, Storage, CPU, etc.) from virtual environment",

--- a/unix/CONTRIBUTING.md
+++ b/unix/CONTRIBUTING.md
@@ -45,9 +45,14 @@ We use the following tools:
 
 ### How to bump Machine Stats version
 
-We use tags to release a new version of machine stats.
-To make a new release, simply create a tag on the `master` branch and the
-`pypi-upload` GitHub Workflow will take care of the rest.
+We use tags to release a new version of machine stats. To make a new release, simply create a tag on the `master` branch and the `pypi-upload` GitHub Workflow will take care of the rest.
+
+To build a new image, you will need to create a release. The steps are pretty simple, You can find Github's instruction [here](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release).
+
+* On the repo page, click on release (right side bar).
+* Create new release.
+* Choose a tag. You should create a new tag for your build. Make sure that you've selected the `master` branch as your target branch.
+* Publish the release.
 
 ### Introducing breaking changes?
 

--- a/unix/CONTRIBUTING.md
+++ b/unix/CONTRIBUTING.md
@@ -45,24 +45,9 @@ We use the following tools:
 
 ### How to bump Machine Stats version
 
-We use [`bump2version`](https://pypi.org/project/bump2version/) to update version numbers.
-
-For example, if the current version in `1.0.0`:
-
-* `pipenv run bump2version patch` will change the version to `1.0.1`
-* `pipenv run bump2version minor` will change the version to `1.1.0`
-* `pipenv run bump2version major` will change the version to `2.0.0`
-
-After that all you need to do is to run
-
-```console
-git push origin master
-git push origin --tags
-```
-
-This will update the version and trigger the PyPI build and deploy.
-
-_Note_: You can verify that the version has been updated after running the `bump2version` command by checking the `config.cfg` file. (current_version)
+We use tags to release a new version of machine stats.
+To make a new release, simply create a tag on the `master` branch and the
+`pypi-upload` GitHub Workflow will take care of the rest.
 
 ### Introducing breaking changes?
 

--- a/unix/setup.cfg
+++ b/unix/setup.cfg
@@ -1,8 +1,3 @@
-[bumpversion]
-commit = True
-tag = True
-current_version = 2.5.4
-
 [flake8]
 ignore = 
 	E203,
@@ -24,7 +19,3 @@ include_trailing_comma = True
 force_grid_wrap = 0
 use_parentheses = True
 line_length = 88
-
-[bumpversion:file:setup.py]
-
-[bumpversion:file:../libvirt/setup.py]

--- a/unix/setup.py
+++ b/unix/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="machine_stats",
-    version="2.5.4",
+    version="develop",
     author="Tidal Migrations",
     author_email="support@tidalmigrations.com",
     description="A simple and effective way to gather machine statistics (RAM, Storage, CPU, etc.) from server environment",


### PR DESCRIPTION
This PR removes the previous approach of using `bump2version` and replaces it with tags. With this, you won't need a dev setup to release a new machine stats version.

To make a new release, simply create a tag on the `master` branch and the `pypi-upload` GitHub Workflow will take care of the rest.