### PR TITLE
Added timestamp when running with -m flag

### DIFF
--- a/unix/src/machine_stats/__init__.py
+++ b/unix/src/machine_stats/__init__.py
@@ -322,6 +322,7 @@ class MeasurementsResultCallback(ResultCallback):
                             server_dict["measurable_type"] = "server"
                             server_dict["field_name"] = custom_field + "_timeseries"
                             server_dict["value"] = server["custom_fields"][custom_field]
+                            server_dict["external_timestamp"] = server["custom_fields"]["cpu_utilization_timestamp"]
                             server_dict["measurable"] = {
                                 "host_name": server["host_name"]
                             }


### PR DESCRIPTION
New output when running with -m, matches new TMP API implimentation.

```
{
    "measurements": [
        {
            "external_timestamp": "2022-08-17 15:21:07",
            "field_name": "cpu_utilization_timeseries",
            "measurable": {
                "host_name": "ip-172-31-47-90"
            },
            "measurable_type": "server",
            "value": 0.0
        }
    ]
}
```