### PR TITLE
MS4W -Measurements

### DIFF
--- a/windows/runner.ps1
+++ b/windows/runner.ps1
@@ -36,7 +36,8 @@ Capture point-in-time CPU utilization value rather than a peak and average over 
 
 .PARAMETER Measurements
 
-Specifies if the data should be output in a structure that matches the TMP /measurements endpoint. This is intended to capture CPU Utilization
+Specifies if the data should be output in a structure that matches the TMP /measurements endpoint. 
+This is intended to capture point-in-time CPU Utilization.
 
 .INPUTS
 
@@ -55,6 +56,8 @@ Adding the -Measurements flag will output JSON which is suitable to pipe to the 
 .EXAMPLE
 
 .\runner.ps1 -UserName myuser
+
+.\runner.ps1 -UserName myuser -Measurements
 
 #>
 [CmdletBinding()]

--- a/windows/runner.ps1
+++ b/windows/runner.ps1
@@ -113,7 +113,7 @@ $secPwd = Get-Content $SecurePwdFilePath | ConvertTo-SecureString
 $cred = New-Object System.Management.Automation.PSCredential -ArgumentList $UserName, $secPwd
 
 try {
-    $env_user = Invoke-Command -ComputerName ([Environment]::MachineName) -Credential $cred -ScriptBlock { $env:USERNAME } -ErrorAction Stop 
+    $env_user = Invoke-Command -ComputerName ([Environment]::MachineName) -Credential $cred -ScriptBlock { $env:USERNAME } -ErrorAction Stop
     Write-Host "Executing inventory gathering as user: $env_user..."
 } catch [System.Management.Automation.Remoting.PSRemotingTransportException] {
     Write-Host "Executing inventory gathering..."
@@ -170,7 +170,7 @@ Do {
 } Until (($jobs | Get-Job | Where-Object { (($_.State -eq "Running") -or ($_.state -eq "NotStarted")) }).count -eq 0)
 
 $jobs | Receive-Job | ForEach-Object {
-    $server_stats += $_
+    $server_stats += $_ | Select -Property * -ExcludeProperty PSComputerName,RunSpaceID,PSShowComputerName
 }
 
 $num_results = $server_stats.Count

--- a/windows/runner.ps1
+++ b/windows/runner.ps1
@@ -36,7 +36,7 @@ Capture point-in-time CPU utilization value rather than a peak and average over 
 
 .PARAMETER Measurements
 
-Specifies if the data should be output in a structure that matches the TMP /measurements endpoint.
+Specifies if the data should be output in a structure that matches the TMP /measurements endpoint. This is intended to capture CPU Utilization
 
 .INPUTS
 

--- a/windows/server_stats.ps1
+++ b/windows/server_stats.ps1
@@ -145,7 +145,7 @@ $ServerStats = {
             measurable_type    = "server"
             value              = $CPUUtilization
             external_timestamp = $CPUUtilizationTimestamp
-            measureable        = New-Object -TypeName psobject -Property @{
+            measurable       = New-Object -TypeName psobject -Property @{
                 host_name = $cpu.SystemName
             }
         }

--- a/windows/server_stats.ps1
+++ b/windows/server_stats.ps1
@@ -25,7 +25,11 @@ $ServerStats = {
 
         [Parameter()]
         [bool]
-        $NoWinRM
+        $NoWinRM=$false,
+
+        [Parameter()]
+        [bool]
+        $Measurements=$false
     )
 
     $getWmiObjectParams = @{
@@ -133,42 +137,60 @@ $ServerStats = {
     }
 
     # Create an object to return, convert this to JSON or CSV as you need:
-    $server_info = New-Object -TypeName psobject -Property @{
-        host_name                = $cpu.SystemName
-        ram_allocated_gb         = $PhysicalMemory 
-        ram_used_gb              = $OSUsedMemory 
-        storage_allocated_gb     = $Total_DriveSpaceGB 
-        storage_used_gb          = $Total_UsedDriveSpaceGB 
-        cpu_count                = $cpu_count
-        operating_system         = $OSInfo.Caption 
-        operating_system_version = $OSInfo.Version 
-        cpu_name                 = $cpu.Name 
-    }
 
-    $custom_fields = New-Object -TypeName psobject -Property @{
-        CPU_Description        = $cpu.Description 
-        CPU_Manufacturer       = $cpu.Manufacturer 
-        CPU_L2CacheSize        = $cpu.L2CacheSize 
-        CPU_L3CacheSize        = $cpu.L3CacheSize 
-        CPU_SocketDesignation  = $cpu.SocketDesignation 
-        TotalVisible_Memory_GB = $OSTotalVisibleMemory
-        TotalVirtual_Memory_GB = $OSTotalVirtualMemory 
-    }
-
-    if ($CpuUtilizationOnlyValue) {
-        $custom_fields | Add-Member -NotePropertyName cpu_utilization -NotePropertyValue $CPUUtilization
-        $custom_fields | Add-Member -NotePropertyName cpu_utilization_timestamp -NotePropertyValue $CPUUtilizationTimestamp
+    # When running with the -Measurements flag, the output will match TMP API /measurements expected data structure
+    if ($Measurements) {
+        $server_info = New-Object -TypeName psobject -Property @{
+            field_name         = "cpu_utilization_timeseries"
+            measurable_type    = "server"
+            value              = $CPUUtilization
+            external_timestamp = $CPUUtilizationTimestamp
+            measureable        = New-Object -TypeName psobject -Property @{
+                host_name = $cpu.SystemName
+            }
+        }
+    # When running without the -Measurements flag, the output will match 'tidal sync servers' expected data structure
     } else {
-        if (!$NoWinRM) {
-            $custom_fields | Add-Member -NotePropertyName cpu_average -NotePropertyValue $CPUUtilization.Average
-            $custom_fields | Add-Member -NotePropertyName cpu_peak -NotePropertyValue $CPUUtilization.Maximum
-            $custom_fields | Add-Member -NotePropertyName cpu_sampling_timeout -NotePropertyValue $CPUUtilization.Count
+        $server_info = New-Object -TypeName psobject -Property @{
+            host_name                = $cpu.SystemName
+            ram_allocated_gb         = $PhysicalMemory 
+            ram_used_gb              = $OSUsedMemory 
+            storage_allocated_gb     = $Total_DriveSpaceGB 
+            storage_used_gb          = $Total_UsedDriveSpaceGB 
+            cpu_count                = $cpu_count
+            operating_system         = $OSInfo.Caption 
+            operating_system_version = $OSInfo.Version 
+            cpu_name                 = $cpu.Name 
+        }
+
+        $custom_fields = New-Object -TypeName psobject -Property @{
+            CPU_Description        = $cpu.Description 
+            CPU_Manufacturer       = $cpu.Manufacturer 
+            CPU_L2CacheSize        = $cpu.L2CacheSize 
+            CPU_L3CacheSize        = $cpu.L3CacheSize 
+            CPU_SocketDesignation  = $cpu.SocketDesignation 
+            TotalVisible_Memory_GB = $OSTotalVisibleMemory
+            TotalVirtual_Memory_GB = $OSTotalVirtualMemory 
+        }
+
+        if ($CpuUtilizationOnlyValue) {
+            $custom_fields | Add-Member -NotePropertyName cpu_utilization -NotePropertyValue $CPUUtilization
+            $custom_fields | Add-Member -NotePropertyName cpu_utilization_timestamp -NotePropertyValue $CPUUtilizationTimestamp
+        } else {
+            if (!$NoWinRM) {
+                $custom_fields | Add-Member -NotePropertyName cpu_average -NotePropertyValue $CPUUtilization.Average
+                $custom_fields | Add-Member -NotePropertyName cpu_peak -NotePropertyValue $CPUUtilization.Maximum
+                $custom_fields | Add-Member -NotePropertyName cpu_sampling_timeout -NotePropertyValue $CPUUtilization.Count
+            }
+        }
+
+        Add-Member -InputObject $server_info -MemberType NoteProperty -Name "custom_fields" -Value $custom_fields
+
+        if ($process_stats) {
+            Add-Member -InputObject $server_info -MemberType NoteProperty -Name "process_stats" -Value $process_stats
         }
     }
 
-    Add-Member -InputObject $server_info -MemberType NoteProperty -Name "custom_fields" -Value $custom_fields
-    if ($process_stats) {
-        Add-Member -InputObject $server_info -MemberType NoteProperty -Name "process_stats" -Value $process_stats
-    }
+    # Return the object
     $server_info
 }


### PR DESCRIPTION
Added the `-Measurements` flag to MS4W. Running with this flag will output the result in a data structure suitable for piping to the TMP /measurements API. 

The intended purpose of this flag is for taking point in time CPU utilization data. Therefore, running with this flag will automatically set `-CpuUtilizationOnlyValue` and `-CpuUtilizationTimeout 1`. This means you don't need to explicitly include these flags in the command when running `-Measurements`. I recommend we make this change to MS4U also. 

The command is as follows:

`./runner.ps1 -UserName Administrator -Measurements`

For piping straight to TMP:

`./runner.ps1 -UserName Administrator -Measurements | tidal request -X POST /api/v1/measurements/import`

This PR also removes the following unnecessary properties from the response object: `PSComputerName, RunSpaceID, PSShowComputerName`. These have been included in the MS4W result since the dawn of time but have never been necessary and were ignored by the TMP API. They are removed in this PR to avoid confusion, as we now only return the data that we need. 

The default (non `-Measurements`) data structure looks like this:

```
{
  "servers": [
    {
      "operating_system": "Microsoft Windows Server 2019 Datacenter",
      "storage_used_gb": 18,
      "ram_used_gb": 0.7,
      "operating_system_version": "10.0.17763",
      "cpu_name": "Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz",
      "storage_allocated_gb": 30,
      "cpu_count": 1,
      "host_name": "EC2AMAZ-S8AS1F2",
      "ram_allocated_gb": 1,
      "custom_fields": {
        "CPU_SocketDesignation": "CPU 0",
        "CPU_Manufacturer": "GenuineIntel",
        "CPU_Description": "Intel64 Family 6 Model 85 Stepping 4",
        "CPU_L3CacheSize": 33792,
        "CPU_L2CacheSize": 24576,
        "TotalVirtual_Memory_GB": 1.97,
        "TotalVisible_Memory_GB": 0.97,
        "cpu_average": 0.13229827366343075,
        "cpu_peak": 1.536958840971847,
        "cpu_sampling_timeout": 30
      }
    },
  ]
}
```

The new `-Measurements` output data structure looks like this:

```
{
  "measurements": [
    {
      "measureable": {
        "host_name": "EC2AMAZ-S8AS1F2"
      },
      "field_name": "cpu_utilization_timeseries",
      "external_timestamp": "2022-08-18 11:04:15",
      "value": 2.4423475111878257,
      "measurable_type": "server"
    },
  ]
}
```