### PR TITLE
Content changes to tidal.cloud

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Tidal Migrations
+Copyright (c) 2023 Tidal
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Machine Stats
 
 A simple and effective way to gather machine statistics (RAM, Storage, CPU)
-from a server environment as a first layer of a [Tidal Migrations discovery
-process](https://guides.tidalmg.com).
+from a server environment as a first layer of a [Tidal Cloud's discovery
+process](https://guides.tidal.cloud/).
 
 Supports Windows and Unix-like platforms.
 
 > _NB: For other platforms or custom integrations, see [the guides
-> here](https://guides.tidalmg.com/sync-servers.html)._
+> here](https://guides.tidal.cloud/sync-servers.html)._
 
 ## Overview
 
@@ -24,20 +24,21 @@ trickery of thin-provisioning from SAN tools.  This allows you to confidently
 plan data replication time, or other migration metrics on an app-by-app basis.
 
 ```
-┌ Machine Stats ─────────────┐                           ╔═ T I D A L   M I G R A T I O N S  ════╗
-│                            │                           ║                                       ║
-│  CPU, RAM, Storage etc.    │                           ║  - Single Source of Truth             ║
-│                            │   `tidal sync servers`    ║  - Server, Database, and              ║
-│                            │──────────────────────────>║    Application Inventory              ║
-│                            │                           ║                                       ║
-│                            │                           ║                                       ║
-└────────────────────────────┘                           ╚═══════════════════════════════════════╝
+┌ Machine Stats ─────────────┐                           ╔═════════ TIDAL CLOUD ═════════╗
+│                            │                           ║                               ║
+│  CPU, RAM, Storage etc.    │                           ║  - Single Source of Truth     ║
+│                            │   `tidal sync servers`    ║  - Server, Database, and      ║
+│                            │──────────────────────────>║    Application Inventory      ║
+│                            │                           ║                               ║
+│                            │                           ║                               ║
+└────────────────────────────┘                           ╚═══════════════════════════════╝
 ```
 
 As your cloud migration will likely take place over many months or years, it's
 important to have current resource requirements throughout your journey. To
 accomplish this, setup `machine_stats` in a cron job or Scheduled Task and
-synchronize your data on a _daily_ basis to Tidal Migrations.
+synchronize your data on a _daily_ basis to Tidal. You can find more information
+about it [here](https://guides.tidal.cloud/machine_stats.html#run-machine-stats-on-a-cron-job).
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Machine Stats
 
 A simple and effective way to gather machine statistics (RAM, Storage, CPU)
-from a server environment as a first layer of a [Tidal Cloud's discovery
-process](https://guides.tidal.cloud/).
+from a server environment as a first layer of a [Tidal discovery process](https://guides.tidal.cloud/).
 
 Supports Windows and Unix-like platforms.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Reporting vulnerabilities
 
-If you think you've identified a security related issue, please email us at security@tidalmigrations.com. This is delivered directly to our engineering and security team. Your email will be acknowledged within one business day, and you'll receive a more detailed response to your email within 7 days indicating the next steps in handling your report.
+If you think you've identified a security related issue, please email us at <security@tidalcloud.com>. This is delivered directly to our engineering and security team. Your email will be acknowledged within one business day, and you'll receive a more detailed response to your email within 7 days indicating the next steps in handling your report.
 
 In addition, please include the following information along with your report:
 

--- a/libvirt/README.md
+++ b/libvirt/README.md
@@ -1,6 +1,6 @@
 # Machine Stats for Hypervisors (Virt-Stats)
 
-A simple and effective way to gather guest VM statistics (hostname, IP addresses) from a [libvirt](https://libvirt.org/)-based environment as a first layer of a [Tidal Migrations discovery process](https://guides.tidalmg.com/). A common use case is to use this to integrate your KVM-based virtual machine inventory into the Tidal Migrations Platform.
+A simple and effective way to gather guest VM statistics (hostname, IP addresses) from a [libvirt](https://libvirt.org/)-based environment as a first layer of a [Tidal's discovery process](https://guides.tidal.cloud/). A common use case is to use this to integrate your KVM-based virtual machine inventory into the [Tidal Accelerator](https://www.tidalcloud.com/accelerator/) Platform.
 
 ## Prerequisutes
 

--- a/libvirt/setup.py
+++ b/libvirt/setup.py
@@ -6,8 +6,8 @@ with open("README.md", "r") as fh:
 setup(
     name="virt_stats",
     version="develop",
-    author="Tidal Migrations",
-    author_email="support@tidalmigrations.com",
+    author="Tidal",
+    author_email="support@tidalcloud.com",
     description="A simple and effective way to gather machine statistics (RAM, Storage, CPU, etc.) from virtual environment",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/unix/README.md
+++ b/unix/README.md
@@ -3,15 +3,15 @@
 [![PyPI](https://img.shields.io/pypi/v/machine-stats)](https://pypi.org/project/machine-stats/)
 
 A simple and effective way to gather machine statistics (RAM, Storage, CPU)
-from a server environment as a first layer of a [Tidal Migrations discovery
-process](https://guides.tidalmg.com).
+from a server environment as a first layer of a [Tidal Cloud's discovery
+process](https://guides.tidal.cloud/).
 
 Machine Stats for Linux/Unix leverages [Ansible](https://www.ansible.com/) to
 gather facts in a cross-platform way.
 
 ## Interactive tutorial
 
-Get familiar with Machine Stats, Tidal Tools and Tidal Migrations Platform!
+Get familiar with Machine Stats, Tidal Tools and Tidal Cloud Platform!
 
 [![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Ftidalmigrations%2Fmachine-stats-workshop&cloudshell_image=gcr.io%2Ftidal-1529434400027%2Fmachine-stats-workshop&cloudshell_tutorial=machine-stats.md&shellonly=true)
 
@@ -19,7 +19,7 @@ Get familiar with Machine Stats, Tidal Tools and Tidal Migrations Platform!
 
 Install locally in a Python 3 environment:
 
-```
+```sh
 python3 -m pip install machine-stats
 ```
 
@@ -31,7 +31,7 @@ _Need to install in an environment without internet access?_ [Checkout how to do
 ### Ubuntu 16.04
 
 1. Make sure `pip` is installed and is one of the latest version available:
-    ```
+    ```sh
     sudo apt update && \
       sudo apt install -y python3-pip && \
       python3 -m pip install --user pip==18.1 && \
@@ -39,69 +39,69 @@ _Need to install in an environment without internet access?_ [Checkout how to do
     ```
     **Note:** Direct upgrade to the latest available `pip` version results with an unusable `pip` installation. That's why we perform the upgrade through the intermediate version (`18.1`).
 2. Install `machine-stats`:
-    ```
+    ```sh
     python3 -m pip install machine-stats
     ```
 
 ### Debian 9/Ubuntu 18.04
 
 1. Make sure `pip` is installed and is one of the latest version:
-    ```
+    ```sh
     sudo apt update && \
       sudo apt install -y python3-pip && \
       python3 -m pip install --upgrade pip
     ```
 2. Install `machine-stats`:
-    ```
+    ```sh
     python3 -m pip install machine-stats
     ```
 
 ### Debian 10/Debian 11/Ubuntu 20.04/Ubuntu 21.04
 
 1. Make sure `pip` is installed:
-    ```
+    ```sh
     sudo apt update && \
       sudo apt install -y python3-pip
     ```
 2. Install `machine-stats`:
-    ```
+    ```sh
     python3 -m pip install machine-stats
     ```
 
 ### CentOS 7/CentOS 8/CentOS Stream/Red Hat Enterprise Linux 7/Red Hat Enterprise Linux 8/Rocky Linux 8
 
 1. Install Python 3:
-    ```
+    ```sh
     sudo yum install -y python3
     ```
 2. Upgrade `pip` to the latest available version:
-    ```
+    ```sh
     python3 -m pip install --upgrade --user pip
     ```
 3. Install `machine-stats`:
-    ```
+    ```sh
     python3 -m pip install machine-stats
     ```
 
 ### SUSE Linux Enterprise Server 12
 
 1. Install Python 3.6:
-    ```
+    ```sh
     sudo zypper install -y python36-base
     ```
 2. Install `machine-stats`:
-    ```
+    ```sh
     pip install machine-stats
     ```
 
 ### SUSE Linux Enterprise Server 15
 
 1. Install `pip`:
-    ```
+    ```sh
     sudo zypper install -y python3-pip
     ```
 2. Install `machine-stats`:
-    ```
+    ```sh
     pip install machine-stats
     ```  
 </details>
@@ -109,7 +109,7 @@ _Need to install in an environment without internet access?_ [Checkout how to do
 ## Data captured
 
 For Linux/Unix based systems, by default, the following metrics are captured
-from the resources and sent and stored in Tidal Migrations:
+from the resources and sent and stored in Tidal Accelerator:
 
 - Host Name
 - FQDN
@@ -133,7 +133,7 @@ You also can optionally capture metrics about processes running on the server:
 - Total Alive Time
 
 To enable capturing process metrics add the command-line flag `--process-stats`:
-```
+```sh
 machine-stats --process-stats
 ```
 
@@ -148,7 +148,7 @@ machine-stats --process-stats
 3. If you need to use a custom SSH identity file for some particular host,
    provide it as the following:
 
-   ```
+   ```sh
    my-user@example.com ansible_ssh_private_key_file=path/to/key-file.pem
    ```
 
@@ -157,14 +157,14 @@ machine-stats --process-stats
    `/usr/bin/python`), add the `ansible_python_interpreter` parameter to the
    `hosts` file after the host IP/domain, for example:
 
-   ```
+   ```text
    freebsd.example.com ansible_python_interpreter=/usr/local/bin/python
    ```
 
 6. Execute `machine-stats` and pipe its output to Tidal Tools:
 
-   ```
-   $ machine-stats | tidal sync servers
+   ```sh
+   machine-stats | tidal sync servers
    ```
 
 ### Additional notes
@@ -173,14 +173,14 @@ By default Machine Stats looks for the `hosts` file in current working
 directory. If your inventory file has another name or is located on another
 path, then you should specify it explicitly:
 
-```
-$ machine-stats /path/to/myhosts | tidal sync servers
+```sh
+machine-stats /path/to/myhosts | tidal sync servers
 ```
 
 You can specify multiple inventory files as the following:
 
-```
-$ machine-stats hosts myhosts /path/to/myhosts
+```sh
+machine-stats hosts myhosts /path/to/myhosts
 ```
 
 ### Configuration
@@ -203,8 +203,8 @@ configuration files in the following locations:
 Also, it is possible to specify the custom configuration file location by
 setting the `ANSIBLE_CONFIG` environment variable, for example:
 
-```
-$ ANSIBLE_CONFIG=/path/to/my/machine_stats.cfg machine_stats /path/to/my/hosts
+```sh
+ANSIBLE_CONFIG=/path/to/my/machine_stats.cfg machine_stats /path/to/my/hosts
 ```
 
 **Note:** if `ANSIBLE_CONFIG` value points to a directory, then Machine Stats
@@ -220,19 +220,19 @@ but installs Python 2.6 alongside with system Python packages.
 1. Download Python 2.6 package and its dependencies from EPEL repository:
 
    ```console
-   $ sudo curl -L -OOO -k \
+     sudo curl -L -OOO -k \
        http://download.fedoraproject.org/pub/archive/epel/5/x86_64/{python26-libs-2.6.8-2.el5.x86_64.rpm,libffi-3.0.5-1.el5.x86_64.rpm,python26-2.6.8-2.el5.x86_64.rpm}
    ```
 
 2. Install the packages:
 
    ```console
-   $ sudo rpm -ivh python26*.rpm libffi*.rpm
+   sudo rpm -ivh python26*.rpm libffi*.rpm
    ```
 
 3. Use non-standard Python location in your `hosts` file:
 
-   ```
+   ```text
    my-user@rhel5.example.com ansible_python_interpreter=/usr/bin/python2.6
    ```
 
@@ -245,45 +245,45 @@ Python versions.
 1. On the machine with internet connection create the packages archive using
    the following commands:
 
-   ```console
-   $ python3 -m pip download -d machine-stats-offline machine-stats
-   $ tar czf machine-stats-offline.tar.gz machine-stats-offline
+   ```sh
+   python3 -m pip download -d machine-stats-offline machine-stats
+   tar czf machine-stats-offline.tar.gz machine-stats-offline
    ```
 
 2. Transfer the archive to the machine where you need to perform the offline
    installation (replace `<remote-host>` and `<remote-dir>` with the
    appropriate values):
 
-   ```console
-   $ scp machine-stats-offline.tar.gz <remote-host>:/<remote-dir>/
+   ```sh
+   scp machine-stats-offline.tar.gz <remote-host>:/<remote-dir>/
    ```
 
 3. On the remote host, extract the archive and switch to extracted directory:
 
-   ```
-   $ tar xf machine-stats-offline.tar.gz
-   $ cd machine-stats-offline
+   ```sh
+   tar xf machine-stats-offline.tar.gz
+   cd machine-stats-offline
    ```
 
 4. Install Machine Stats and its dependencies:
 
-   ```
-   $ python3 -m pip install --no-index --find-links . machine_stats-*.whl
+   ```sh
+   python3 -m pip install --no-index --find-links . machine_stats-*.whl
    ```
 
-## Generating a `hosts` file from Tidal Migrations
+## Generating a `hosts` file from Tidal Accelerator
 
 You can easily generate a hosts file directly from your server inventory in
-Tidal Migrations. For example you can use this command:
+Tidal Accelerator. For example you can use this command:
 
-```
+```sh
 tidal export servers | jq '.[].host_name' > hosts
 ```
 
 This will create a file (`hosts`), in your current directory, that you can
 use above in Step 1.
 
-Alternatively, if you use Tidal Migrations [Ansible Tower integration
+Alternatively, if you use Tidal Accelerator [Ansible Tower integration
 script](https://github.com/tidalmigrations/ansible-tower-integration) you can
 use its output to generate the `hosts` file for `machine_stats`.
 
@@ -293,7 +293,7 @@ use its output to generate the `hosts` file for `machine_stats`.
 
 ### Usage
 
-```
+```sh
 cd ansible-tower-integration
 ./tidal_inventory.py | jq -r '.servers.hosts[]' > path/to/hosts
 ```
@@ -304,8 +304,8 @@ cd ansible-tower-integration
 
 If running Machine Stats as a CLI failed, try running it as the following:
 
-```console
-$ python3 -m machine_stats
+```sh
+python3 -m machine_stats
 ```
 
 ### How to permanently enable the Python 3.8 software collection on RHEL 7
@@ -313,7 +313,7 @@ $ python3 -m machine_stats
 You should always enable the Python software collection before using `pipenv`
 with the following command:
 
-```
+```sh
 scl enable rh-python38 bash
 ```
 
@@ -323,7 +323,7 @@ is that the collection is already enabled at every login.
 
 Using your preferred text editor, add the following line to your `~/.bashrc`:
 
-```
+```sh
 # Add RHSCL Python 3 to my login environment
 source scl_source enable rh-python38
 ```

--- a/unix/README.md
+++ b/unix/README.md
@@ -3,15 +3,14 @@
 [![PyPI](https://img.shields.io/pypi/v/machine-stats)](https://pypi.org/project/machine-stats/)
 
 A simple and effective way to gather machine statistics (RAM, Storage, CPU)
-from a server environment as a first layer of a [Tidal Cloud's discovery
-process](https://guides.tidal.cloud/).
+from a server environment as a first layer of a [Tidal discovery process](https://guides.tidal.cloud/).
 
 Machine Stats for Linux/Unix leverages [Ansible](https://www.ansible.com/) to
 gather facts in a cross-platform way.
 
 ## Interactive tutorial
 
-Get familiar with Machine Stats, Tidal Tools and Tidal Cloud Platform!
+Get familiar with Machine Stats, Tidal Tools and Tidal Accelerator!
 
 [![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Ftidalmigrations%2Fmachine-stats-workshop&cloudshell_image=gcr.io%2Ftidal-1529434400027%2Fmachine-stats-workshop&cloudshell_tutorial=machine-stats.md&shellonly=true)
 

--- a/unix/setup.py
+++ b/unix/setup.py
@@ -6,8 +6,8 @@ with open("README.md", "r") as fh:
 setup(
     name="machine_stats",
     version="develop",
-    author="Tidal Migrations",
-    author_email="support@tidalmigrations.com",
+    author="Tidal SW",
+    author_email="support@tidalcloud.com",
     description="A simple and effective way to gather machine statistics (RAM, Storage, CPU, etc.) from server environment",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/windows/README.md
+++ b/windows/README.md
@@ -6,7 +6,7 @@ If WinRM is not the best solution for you, you can use an alternative approach b
 
 ## Usage
 
-For detailed information on the different ways to run Machine Stats for Windows, check out the [guide](https://guides.tidal.cloud/machine_stats.html#windows). This README will explain one common use case - where you want to take a single reading of your inventory and then pipe the result straight to the Tidal Accelerator platform using Tidal Tools.
+For detailed information on the different ways to run Machine Stats for Windows, check out the [guide](https://guides.tidal.cloud/machine_stats.html#windows). This README will explain one common use case - where you want to take a single reading of your inventory and then pipe the result straight to Tidal Accelerator using Tidal Tools.
 
 1. Download and install [Tidal Tools](https://get.tidal.sh/).
 

--- a/windows/README.md
+++ b/windows/README.md
@@ -1,42 +1,44 @@
 # Machine Stats for Windows
 
-Machine Stats for Windows uses WinRM to `Invoke-Command` across your servers, creating a JSON file which you can securely send to your [Tidal Migrations](https://tidalmigrations.com/) instance using the [tidal command](https://tidalmigrations.com/tidal-tools/).
+Machine Stats for Windows uses WinRM to `Invoke-Command` across your servers, creating a JSON file which you can securely send to your [Tidal Accelerator](https://tidalcloud.com/) instance using the [tidal command](https://tidalcloud.com/tidal-tools/).
 
-If WinRM is not the best solution for you, you can use an alternative approach backed by WMI by running the `-NoWinRM` flag. For more information check out the [guide](https://guides.tidalmg.com/machine_stats.html#gather-machine-stats-without-winrm).
+If WinRM is not the best solution for you, you can use an alternative approach backed by WMI by running the `-NoWinRM` flag. For more information check out the [guide](https://guides.tidal.cloud/machine_stats.html#gather-machine-stats-without-winrm).
 
 ## Usage
 
-For detailed information on the different ways to run Machine Stats for Windows, check out the [guide](https://guides.tidalmg.com/machine_stats.html#windows). This README will explain one common use case - where you want to take a single reading of your inventory and then pipe the result straight to the Tidal Migrations platform using Tidal Tools.
+For detailed information on the different ways to run Machine Stats for Windows, check out the [guide](https://guides.tidal.cloud/machine_stats.html#windows). This README will explain one common use case - where you want to take a single reading of your inventory and then pipe the result straight to the Tidal Accelerator platform using Tidal Tools.
 
-1) Download and install [Tidal Tools](https://get.tidal.sh/).
+1. Download and install [Tidal Tools](https://get.tidal.sh/).
 
-2) Make sure you are logged in to your Tidal Migration workspace with 👇 . Check out the [guides](https://guides.tidalmg.com/tidal-tools.html#using-tidal-tools) for more information.
-```
-tidal login
-```
+2. Make sure you are logged into your Tidal Accelerator workspace with 👇 . Check out the [guides](https://guides.tidal.cloud/tidal-tools.html#using-tidal-tools) for more information.
 
-3) Prepare the username and a password to access your servers:
+   ```sh
+   tidal login
+   ```
+
+3. Prepare the username and a password to access your servers:
     - Specify `-UserName` parameter value
     - Store the password securely by running `.\save_password.ps1` script
 
-4) Ensure you have a text file (unicode/ascii) that has a list of hosts to be scanned. Hosts can be specified either as IP addresses or as hostnames that resolve via DNS. In either case, the hostnames and IP addresses must be resolvable (private or global DNS) and routable (either locally or over the internet) from the machine that machine-stats is running on. By default, Machine Stats looks for `servers.txt`, but you can also specify any custom location with `-ServersPath` parameter.
+4. Ensure you have a text file (unicode/ascii) that has a list of hosts to be scanned. Hosts can be specified either as IP addresses or as hostnames that resolve via DNS. In either case, the hostnames and IP addresses must be resolvable (private or global DNS) and routable (either locally or over the internet) from the machine that machine-stats is running on. By default, Machine Stats looks for `servers.txt`, but you can also specify any custom location with `-ServersPath` parameter.
 
-   You can easily export these with the 'Export' button from your Tidal Migrations account, https://your_domain.tidalmg.com/#/servers
+   You can easily export these with the 'Export' button from your Tidal Accelerator workspace, <https://your_domain.tidal.cloud/#/servers>
 
-5) Invoke the runner and sync with Tidal Migrations:
-```
+5. Invoke the runner and sync with Tidal Accelerator:
+
+```sh
 .\windows\runner.ps1 | tidal sync servers
 ```
 
 You should be able to check your account and see the VMs and their corresponding attributes and metrics. You'll find that at a URL that is something like:
 
-`https://your_domain.tidalmg.com/#/servers`
+`https://your_domain.tidal.cloud/#/servers`
 
 ## Data captured
 
-For Windows, by default, the following metrics are captured from the resources and sent and stored in Tidal Migrations:
+For Windows, by default, the following metrics are captured from the resources and sent and stored in Tidal Accelerator:
 
-```
+```text
 Host Name
 RAM Allocated (GB)
 RAM Used (GB)
@@ -56,7 +58,8 @@ Total Virtual Memory (GB)
 ```
 
 You can also capture information about processes running on the host machine. This feature is disabled by default, to enable it use the flag `-ProcessStats`. Note that this will only work when using WinRM, and so can't be used alongside the `-NoWinRM` flag. Running this flag will gather the following information about a process:
-```
+
+```text
 User
 Process Name
 Process Path
@@ -66,7 +69,6 @@ Total Alive Time in Seconds
 ```
 
 *NB: The names must match the names above exactly. If you wish to change these or add other values you can do so at the end of the file in [windows/server_stats.ps1](windows/server_stats.ps1)*
-
 
 ## Troubleshooting
 
@@ -78,7 +80,7 @@ If you see an error that says:
 
 You can allow the script to be run by executing the following:
 
-```
+```sh
 Set-ExecutionPolicy -ExecutionPolicy ByPass -Scope CurrentUser
 ```
 
@@ -92,7 +94,7 @@ If an error is returned describing that
 
 You can resolve this by running this command:
 
-```
+```sh
 Set-Item WSMan:localhost\client\trustedhosts -value *
 ```
 

--- a/windows/runner.ps1
+++ b/windows/runner.ps1
@@ -47,7 +47,7 @@ None. You cannot pipe objects to runner.ps1
 
 Default behaviour will output JSON which is suitable to pipe to the Tidal Tools command "tidal sync servers".
 
-Adding the -Measurements flag will output JSON which is suitable to pipe to the Tidal Migrations Platform /measurements API endpoint.
+Adding the -Measurements flag will output JSON which is suitable to pipe to the Tidal Accelerator Platform /measurements API endpoint.
 
 .EXAMPLE
 


### PR DESCRIPTION
Content changes to replace the reference to `tidalmg.com` with `tidal.cloud`, Tidal Migrations with Tidal, logos, and reference to Accelerator where appropriate.