### PR TITLE
Update copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Tidal
+Copyright (c) 2024 Tidal
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
While from a legal standpoint, the effectiveness and enforceability of the MIT license do not depend on the date being current, it does reflect currentness and consistency across our apps.
This PR will be merged in Jan'24.