### PR TITLE
Revert "Add curl request to trigger the publish-ami workflow (#134)"

### DIFF
--- a/.github/workflows/pypi-upload.yml
+++ b/.github/workflows/pypi-upload.yml
@@ -46,18 +46,6 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
           twine upload --verbose -u '__token__' dist/*
-
-      # This step triggers the publish-amis workflow here
-      #   https://github.com/tidalmigrations/Infrastructure-templates/blob/main/.github/workflows/publish-images.yml
-      - name: Trigger publish-ami workflow
-        run: |
-          curl -X POST \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB }}" \
-            --data '{"event_type":"publish_amis"}' \
-            https://api.github.com/repos/tidalmigrations/Infrastructure-templates/dispatches
-
-
   virt_stats:
     name: Virt Stats PyPI Upload
     runs-on: ubuntu-latest


### PR DESCRIPTION
This reverts commit de8f954f4067010a8cbb6bb512163893592c4028.

This is no longer needed since it was only added to benchmark machine stats. 