### PR TITLE
feat(unix): add Python version constraints and development environment

### DIFF
--- a/unix/README.md
+++ b/unix/README.md
@@ -14,6 +14,11 @@ Get familiar with Machine Stats, Tidal Tools and Tidal Accelerator!
 
 [![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Ftidalmigrations%2Fmachine-stats-workshop&cloudshell_image=gcr.io%2Ftidal-1529434400027%2Fmachine-stats-workshop&cloudshell_tutorial=machine-stats.md&shellonly=true)
 
+## Requirements
+
+- **Python**: 3.6 - 3.11 (Python 3.12+ is not supported due to Ansible 2.9.x compatibility)
+- **Operating System**: Linux/Unix-like systems
+
 ## Installation
 
 Install locally in a Python 3 environment:

--- a/unix/dev-env.sh
+++ b/unix/dev-env.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Development environment setup script for machine-stats
+# Run this script with: source dev-env.sh
+
+echo "Setting up development environment for machine-stats..."
+
+# Initialize pyenv
+eval "$(pyenv init -)"
+
+# Check if we're using the correct Python version
+current_version=$(python --version 2>&1 | cut -d' ' -f2)
+expected_version="3.11.13"
+
+if [[ "$current_version" == "$expected_version" ]]; then
+    echo "✓ Using Python $current_version"
+else
+    echo "⚠ Python version mismatch. Expected $expected_version, got $current_version"
+    echo "Setting local Python version to $expected_version..."
+    pyenv local $expected_version
+fi
+
+# Verify machine-stats is installed in development mode
+if pip list | grep -q "machine_stats.*dev0.*$(pwd)"; then
+    echo "✓ machine-stats is installed in development mode"
+else
+    echo "⚠ machine-stats not found in development mode. Installing..."
+    pip install -e .
+fi
+
+echo "✓ Development environment ready!"
+echo ""
+echo "You can now use:"
+echo "  machine-stats --help"
+echo "  machine_stats --help"
+echo ""
+echo "Any changes you make to the source code will be immediately reflected." 

--- a/unix/setup.py
+++ b/unix/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="machine_stats",
-    version="develop",
+    version="0.0.1.dev0",
     author="Tidal SW",
     author_email="support@tidalcloud.com",
     description="A simple and effective way to gather machine statistics (RAM, Storage, CPU, etc.) from server environment",
@@ -18,6 +18,23 @@ setup(
     install_requires=[
         "ansible<2.10",
         "pluginbase==1.0.1",
+    ],
+    python_requires=">=3.6,<3.12",
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: System Administrators",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: POSIX :: Linux",
+        "Operating System :: Unix",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Topic :: System :: Systems Administration",
+        "Topic :: System :: Monitoring",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
- Add python_requires=">=3.6,<3.12" to setup.py to enforce compatibility
- Add Python version classifiers for better PyPI metadata
- Document Python version requirements in README.md
- Add dev-env.sh script for easy development environment setup

This change addresses the incompatibility with Python 3.12+ due to Ansible 2.9.x dependency limitations. The project now officially supports Python 3.6 through 3.11.